### PR TITLE
fix support for Symfony 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.3.3",
         "twig/twig": "~1.2",
         "symfony/framework-bundle" : "~2.2",
-        "fsi/datagrid": "1.0.*"
+        "fsi/datagrid": "1.1.*"
     },
     "autoload": {
         "psr-0": { "FSi\\Bundle\\DataGridBundle\\": "" }


### PR DESCRIPTION
Only the 1.1 version of the Datagrid component supports Symfony 2.3

See also https://github.com/fsi-open/data-indexer/pull/3
