### PR TITLE
Added datagrid_column_type_action_cell_action_widget to twig

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,12 @@ Example:
 * datagrid_{grid_name}_column_cell_form
 * datagrid_column_cell_form
 
+``datagrid_column_type_action_cell_action_widget``
+* datagrid_{grid_name}_column_type_action_cell_action_{action_name}
+* datagrid_column_type_action_cell_action_{action_name}
+* datagrid_{grid_name}_column_type_action_cell_action
+* datagrid_column_type_action_cell_action
+
 As you can see there are many ways to overwrite default block even for specific column in specific grid.
 
 # Exports #

--- a/Resources/views/datagrid.html.twig
+++ b/Resources/views/datagrid.html.twig
@@ -28,16 +28,16 @@
 {% endspaceless %}
 {% endblock %}
 
+{% block datagrid_column_type_action_cell_action %}
+<a {% for attrname, attrvalue in attr %}{% if attrname == 'title' %}{{ attrname }}="{{ attrvalue|trans({}, translation_domain) }}" {% else %}{{ attrname }}="{{ attrvalue }}" {% endif %}{% endfor %}>{{ content|trans({}, translation_domain)|raw }}</a>
+{% endblock %}
+
 {% block datagrid_column_type_action_cell %}
 {% spaceless %}
     <td>
         <div>
             {% for action_name, action in cell.value %}
-                {% spaceless %}
-                <a {% for attrname, attrvalue in action.url_attr %}{% if attrname == 'title' %}{{ attrname }}="{{ attrvalue|trans({}, translation_domain) }}" {% else %}{{ attrname }}="{{ attrvalue }}" {% endif %}{% endfor %}>
-                    {{ action.content|trans({}, translation_domain)|raw }}
-                </a>
-                {% endspaceless %}
+                {{ datagrid_column_type_action_cell_action_widget(cell, action_name, action.content, action.url_attr|merge({'href' : action.url}, action.field_mapping_values)) }}
             {% endfor %}
         </div>
     </td>

--- a/Tests/Resources/views/datagrid/action_cell_action_widget_test.html.twig
+++ b/Tests/Resources/views/datagrid/action_cell_action_widget_test.html.twig
@@ -1,0 +1,6 @@
+{% datagrid_theme grid_with_header_theme 'datagrid/themes.html.twig' %}
+
+{# datagrid_column_type_action_cell_action_widget test #}
+{{ datagrid_column_type_action_cell_action_widget(cell, 'edit', 'content', {'href' : '#'}, {'id' : 1}) }}
+
+{{ datagrid_column_type_action_cell_action_widget(cell_with_theme, 'edit', 'content', {'href' : '#'}, {'id' : 1}) }}

--- a/Tests/Resources/views/datagrid/themes.html.twig
+++ b/Tests/Resources/views/datagrid/themes.html.twig
@@ -27,3 +27,9 @@
     <h1>This is column cell theme</h1>
 {% endspaceless %}
 {% endblock %}
+
+{% block datagrid_column_type_action_cell_action %}
+{% spaceless %}
+    <h1>This is column cell with type action theme for custom action</h1>
+{% endspaceless %}
+{% endblock %}

--- a/Tests/Resources/views/expected/datagrid/action_cell_action_widget_result.html
+++ b/Tests/Resources/views/expected/datagrid/action_cell_action_widget_result.html
@@ -1,0 +1,5 @@
+
+<a href="#" >[trans]content[/trans]</a>
+
+
+<h1>This is column cell with type action theme for custom action</h1>

--- a/Tests/Twig/Extension/DataGridExtensionTest.php
+++ b/Tests/Twig/Extension/DataGridExtensionTest.php
@@ -151,6 +151,29 @@ class DataGridExtensionTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testRenderCellActionWidget()
+    {
+        $this->twig->addExtension($this->extension);
+        $this->twig->initRuntime();
+
+        $datagridView = $this->getDataGridView('grid');
+        $datagridWithThemeView = $this->getDataGridView('grid_with_header_theme');
+
+        $cellView = $this->getColumnCellView($datagridView, 'actions', 'action', array());
+        $cellWithThemeView = $this->getColumnCellView($datagridWithThemeView, 'actions', 'action', array());
+
+        $html = $this->twig->render('datagrid/action_cell_action_widget_test.html.twig', array(
+            'grid_with_header_theme' => $datagridWithThemeView,
+            'cell' => $cellView,
+            'cell_with_theme' => $cellWithThemeView,
+        ));
+
+        $this->assertSame(
+            $html,
+            $this->getExpectedHtml('datagrid/action_cell_action_widget_result.html')
+        );
+    }
+
     public function testDataGridRenderBlock()
     {
         $this->twig->addExtension($this->extension);
@@ -427,6 +450,55 @@ class DataGridExtensionTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         $this->extension->datagridColumnCellForm($cellView);
+    }
+
+
+    public function testDataGridColumnActionCellActionRenderBlock()
+    {
+        $this->twig->addExtension($this->extension);
+        $this->twig->initRuntime();
+        $template = $this->getMock('\Twig_TemplateInterface', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock'));
+
+        $template->expects($this->at(0))
+            ->method('hasBlock')
+            ->with('datagrid_grid_column_type_action_cell_action_edit')
+            ->will($this->returnValue(false));
+
+        $template->expects($this->at(1))
+            ->method('hasBlock')
+            ->with('datagrid_column_type_action_cell_action_edit')
+            ->will($this->returnValue(false));
+
+        $template->expects($this->at(2))
+            ->method('hasBlock')
+            ->with('datagrid_grid_column_type_action_cell_action')
+            ->will($this->returnValue(false));
+
+        $template->expects($this->at(3))
+            ->method('hasBlock')
+            ->with('datagrid_column_type_action_cell_action')
+            ->will($this->returnValue(true));
+
+        $this->extension->setBaseTheme($template);
+        $datagridView = $this->getDataGridView('grid');
+        $cellView = $this->getColumnCellView($datagridView, 'action', 'actions', array());
+
+        $cellView->expects($this->any())
+            ->method('getAttribute')
+            ->with('translation_domain')
+            ->will($this->returnValue(null));
+
+        $template->expects($this->at(4))
+            ->method('displayBlock')
+            ->with('datagrid_column_type_action_cell_action', array(
+                'content' => 'content',
+                'attr' => array(),
+                'translation_domain' => null,
+                'field_mapping_values' => array()
+            ))
+            ->will($this->returnValue(true));
+
+        $this->extension->datagridColumnActionCellActionWidget($cellView, 'edit', 'content');
     }
 
     private function getDataGridView($name)

--- a/Twig/Extension/DataGridExtension.php
+++ b/Twig/Extension/DataGridExtension.php
@@ -82,6 +82,7 @@ class DataGridExtension extends \Twig_Extension
             'datagrid_column_header_widget' =>  new \Twig_Function_Method($this, 'datagridColumnHeader', array('is_safe' => array('html'))),
             'datagrid_column_cell_widget' =>  new \Twig_Function_Method($this, 'datagridColumnCell', array('is_safe' => array('html'))),
             'datagrid_column_cell_form_widget' =>  new \Twig_Function_Method($this, 'datagridColumnCellForm', array('is_safe' => array('html'))),
+            'datagrid_column_type_action_cell_action_widget' =>  new \Twig_Function_Method($this, 'datagridColumnActionCellActionWidget', array('is_safe' => array('html'))),
             'datagrid_attributes_widget' =>  new \Twig_Function_Method($this, 'datagridAttributes', array('is_safe' => array('html')))
         );
     }
@@ -288,6 +289,34 @@ class DataGridExtension extends \Twig_Extension
                 $this->getVars($view->getDataGridView()),
                 $vars
             )
+        );
+
+        return $this->renderTheme($dataGridView, $context, $blockNames);
+    }
+
+    /**
+     * @param CellViewInterface $view
+     * @param $action
+     * @param $content
+     * @param array $urlAttrs
+     * @param array $fieldMappingValues
+     * @return string
+     */
+    public function datagridColumnActionCellActionWidget(CellViewInterface $view, $action, $content, $urlAttrs = array(), $fieldMappingValues = array())
+    {
+        $dataGridView = $view->getDataGridView();
+        $blockNames = array(
+            'datagrid_' . $dataGridView->getName() . '_column_type_action_cell_action_' . $action,
+            'datagrid_column_type_action_cell_action_' . $action ,
+            'datagrid_' . $dataGridView->getName() . '_column_type_action_cell_action',
+            'datagrid_column_type_action_cell_action',
+        );
+
+        $context = array(
+            'content' => $content,
+            'attr' => $urlAttrs,
+            'translation_domain' => $view->getAttribute('translation_domain'),
+            'field_mapping_values' => $fieldMappingValues
         );
 
         return $this->renderTheme($dataGridView, $context, $blockNames);


### PR DESCRIPTION
`datagrid_column_type_action_cell_action_widget` is somethig that allows theming single actions in `action` column type. 

Lets asume we have action `edit`. 
Up to now to create such actions the following configuration of action column type was required: 

```
$datagrid->addColumn('actions', 'action',array(
    'label' => "Actions",
    'field_mapping' => array('id'),
    'actions' => array(
        'edit' => array(
            'url_attr' => array(
                'class' => 'btn btn-warning btn-small-horizontal',
                'title' => 'crud.list.datagrid.action.edit'
            ),
            'content' => '<span class="icon-eject icon-white"></span>',
            'route_name' => 'fsi_admin_crud_edit',
            'parameters_field_mapping' => array(
                'id' => 'id'
            ),
        )
    )
));
```

From now it also can be done by: 

```
$datagrid->addColumn('actions', 'action',array(
    'label' => "Actions",
    'field_mapping' => array('id'),
    'actions' => array(
        'edit' => array(
            'route_name' => 'fsi_admin_crud_edit',
            'parameters_field_mapping' => array(
                'id' => 'id'
            ),
        )
    )
));
```

with following block in DataGrid theme template file: 

```
{# Resources/views/datagrid.html.twig #}

{% block datagrid_column_type_action_cell_action_edit %}
    {% spaceless %}
        <a href="{{ attr.href }}" title="{{ 'crud.list.datagrid.action.edit'|trans }}" class="btn btn-warning btn-small-horizontal">
            <span class="icon-eject icon-white"></span>
        </a>
    {% endspaceless %}
{% endblock %}
```

`url_attr` and `content` options are still available in action configuration. 
