### PR TITLE
move symfony extensions to bundle

### DIFF
--- a/DataGrid/Extension/ColumnType/Action.php
+++ b/DataGrid/Extension/ColumnType/Action.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\DataGridBundle\DataGrid\Extension\ColumnType;
+
+use FSi\Component\DataGrid\Column\ColumnAbstractType;
+use FSi\Component\DataGrid\Exception\UnexpectedTypeException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class Action extends ColumnAbstractType
+{
+    /**
+     * Symfony Router to generate urls.
+     *
+     * @var \Symfony\Component\Routing\Router;
+     */
+    protected $router;
+
+    /**
+     * Service container used to access current request.
+     *
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @var \Symfony\Component\OptionsResolver\OptionsResolver
+     */
+    protected $actionOptionsResolver;
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+        $this->router = $container->get('router');
+        $this->actionOptionsResolver = new OptionsResolver();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return 'action';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filterValue($value)
+    {
+        $return = array();
+        $actions = $this->getOption('actions');
+
+        foreach ($actions as $name => $options) {
+            $options = $this->actionOptionsResolver->resolve((array) $options);
+            $return[$name] = array();
+            $parameters = array();
+            $urlAttributes = $options['url_attr'];
+            $content = $options['content'];
+
+            if (isset($options['parameters_field_mapping'])) {
+                foreach ($options['parameters_field_mapping'] as $parameterName => $mappingField) {
+                    if ($mappingField instanceof \Closure) {
+                        $parameters[$parameterName] = $mappingField($value, $this->getIndex());
+                    } else {
+                        $parameters[$parameterName] = $value[$mappingField];
+                    }
+                }
+            }
+
+            if (isset($options['additional_parameters'])) {
+                foreach ($options['additional_parameters'] as $parameterValueName => $parameterValue) {
+                    $parameters[$parameterValueName] = $parameterValue;
+                }
+            }
+
+            if ($options['redirect_uri'] !== false) {
+                if (is_string($options['redirect_uri'])) {
+                    $parameters['redirect_uri'] = $options['redirect_uri'];
+                }
+
+                if ($options['redirect_uri'] === true) {
+                    $parameters['redirect_uri'] = $this->container->get('request')->getUri();
+                }
+            }
+
+            if ($urlAttributes instanceof \Closure) {
+                $urlAttributes = $urlAttributes($value, $this->getIndex());
+
+                if (!is_array($urlAttributes)) {
+                    throw new UnexpectedTypeException('url_attr option Clousure must return new array with url attributes.');
+                }
+            }
+
+            $url = $this->router->generate($options['route_name'], $parameters, $options['absolute']);
+
+            if (!isset($urlAttributes['href'])) {
+                $urlAttributes['href'] = $url;
+            }
+
+            if (isset($content) && $content instanceof \Closure) {
+                $content = (string) $content($value, $this->getIndex());
+            }
+
+            // $return[$name]['url'] is deprecated since 1.0 and will be removed in version 1.2
+            $return[$name]['url'] = $url;
+            $return[$name]['content']  = isset($content) ? $content : $name;
+            $return[$name]['field_mapping_values'] = $value;
+            $return[$name]['url_attr'] = $urlAttributes;
+        }
+
+        return $return;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initOptions()
+    {
+        $this->getOptionsResolver()->setDefaults(array(
+            'actions' => array(),
+        ));
+
+        $this->getOptionsResolver()->setAllowedTypes(array(
+            'actions' => 'array',
+        ));
+
+        $this->actionOptionsResolver->setDefaults(array(
+            'redirect_uri' => true,
+            'absolute' => false,
+            'url_attr' => array(),
+            'content' => null,
+            'parameters_field_mapping' => array(),
+            'additional_parameters' => array(),
+        ));
+
+        $this->actionOptionsResolver->setAllowedTypes(array(
+            'url_attr' => array('array', 'Closure'),
+            'content' => array('null', 'string', 'Closure')
+        ));
+
+        $this->actionOptionsResolver->setRequired(array(
+            'route_name',
+        ));
+    }
+}

--- a/DataGrid/Extension/ColumnTypeExtension/ActionColumnExtension.php
+++ b/DataGrid/Extension/ColumnTypeExtension/ActionColumnExtension.php
@@ -1,0 +1,187 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\DataGridBundle\DataGrid\Extension\ColumnTypeExtension;
+
+use FSi\Component\DataGrid\Column\ColumnTypeInterface;
+use FSi\Component\DataGrid\Column\ColumnAbstractTypeExtension;
+use Symfony\Component\Routing\RouterInterface;
+
+class ActionColumnExtension extends ColumnAbstractTypeExtension
+{
+    /**
+     * Symfony Router to generate urls.
+     *
+     * @var \Symfony\Component\Routing\Router;
+     */
+    protected $router;
+
+    /**
+     * Default values for action options if not passed in column configuration.
+     *
+     * @var array
+     */
+    protected $actionOptionsDefault = array(
+        'absolute' => false,
+    );
+
+    /**
+     * Available action options.
+     *
+     * @var array
+     */
+    protected $actionOptionsAvailable = array(
+        'parameters',
+        'parameters_values',
+        'anchor',
+        'route_name',
+        'absolute',
+    );
+
+    /**
+     * Options required in action.
+     *
+     * @var array
+     */
+    protected $actionOptionsRequired = array(
+        'anchor',
+        'route_name',
+    );
+
+    /**
+     * @param \Symfony\Component\Routing\RouterInterface $router
+     */
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filterValue(ColumnTypeInterface $column, $value)
+    {
+        $this->validateOptions($column);
+
+        $return = array();
+        $actions = $column->getOption('actions');
+
+        foreach ($actions as $name => $options) {
+            $return[$name] = array(
+                'name' => $name,
+                'anchor' => $options['anchor'],
+            );
+
+            $parameters = array();
+            if (isset($options['parameters'])) {
+                foreach ($options['parameters'] as $mappingField => $parameterName) {
+                    $parameters[$parameterName] = $value[$mappingField];
+                }
+            }
+
+            if (isset($options['parameters_values'])) {
+                foreach ($options['parameters_values'] as $parameterValueName => $parameterValue) {
+                    $parameters[$parameterValueName] = $parameterValue;
+                }
+            }
+
+            $url = $this->router->generate($options['route_name'], $parameters, $options['absolute']);
+
+            $return[$name]['url'] = $url;
+        }
+
+        return $return;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtendedColumnTypes()
+    {
+        return array('action');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequiredOptions(ColumnTypeInterface $column)
+    {
+        return array('actions');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAvailableOptions(ColumnTypeInterface $column)
+    {
+        return array('actions');
+    }
+
+    /**
+     * @param \FSi\Component\DataGrid\Column\ColumnTypeInterface $column
+     * @throws \InvalidArgumentException
+     */
+    private function validateOptions(ColumnTypeInterface $column)
+    {
+        $actions = $column->getOption('actions');
+        if (!is_array($actions)) {
+            throw new \InvalidArgumentException('Option "actions" must be an array.');
+        }
+
+        if (!count($actions)) {
+            throw new \InvalidArgumentException('Option actions can\'t be empty.');
+        }
+
+        foreach ($actions as $actionName => &$options) {
+            if (!is_array($options)) {
+                throw new \InvalidArgumentException(sprintf('Options for action "%s" must be an array.', $actionName));
+            }
+
+            foreach ($options as $optionName => $value) {
+                if (!in_array($optionName, $this->actionOptionsAvailable)) {
+                    throw new \InvalidArgumentException(sprintf('Unknown option "%s" in action "%s".', $optionName, $actionName));
+                }
+            }
+
+            foreach ($this->actionOptionsRequired as $optionName) {
+                if (!array_key_exists($optionName, $options)) {
+                    throw new \InvalidArgumentException(sprintf('Action "%s" require option "%s".', $actionName, $optionName));
+                }
+            }
+
+            foreach ($this->actionOptionsDefault as $optionName => $value) {
+                if (!array_key_exists($optionName, $options)) {
+                    $options[$optionName] = $value;
+                }
+            }
+
+            if (isset($options['parameters_values'])) {
+                if (!is_array($options['parameters_values'])) {
+                    throw new \InvalidArgumentException(sprintf('Action "%s" require option "parameters_values" as array.', $actionName, $optionName));
+                }
+            }
+
+            if (isset($options['parameters'])) {
+                if (!is_array($options['parameters'])) {
+                    throw new \InvalidArgumentException(sprintf('Action "%s" require option "parameters" as array.', $actionName, $optionName));
+                }
+
+                $mappingFields = $column->getOption('field_mapping');
+
+                foreach ($options['parameters'] as $mappingField => $routerParameter) {
+                    if (!in_array($mappingField, $mappingFields, true)) {
+                        throw new \InvalidArgumentException(sprintf('Unknown mapping_field "%s". Maybe you should consider using option "parameters_values"?', $mappingField));
+                    }
+                }
+            }
+        }
+
+        $column->setOption('actions', $actions);
+    }
+}

--- a/DataGrid/Extension/ColumnTypeExtension/FormExtension.php
+++ b/DataGrid/Extension/ColumnTypeExtension/FormExtension.php
@@ -1,0 +1,266 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\DataGridBundle\DataGrid\Extension\ColumnTypeExtension;
+
+use FSi\Component\DataGrid\DataGridInterface;
+use FSi\Component\DataGrid\Column\ColumnTypeInterface;
+use FSi\Component\DataGrid\Column\CellViewInterface;
+use FSi\Component\DataGrid\Column\ColumnAbstractTypeExtension;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+
+class FormExtension extends ColumnAbstractTypeExtension
+{
+    /**
+     * @var string
+     */
+    protected $formName;
+
+    /**
+     * @var \Symfony\Component\Form\FormFactoryInterface
+     */
+    protected $formFactory;
+
+    /**
+     * Form Objects instances created by method CreateForm.
+     *
+     * @var array
+     */
+    protected $forms = array();
+
+    /**
+     * @param \Symfony\Component\Form\FormFactoryInterface $formFactory
+     */
+    public function __construct(FormFactoryInterface $formFactory)
+    {
+        $this->formFactory = $formFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDataGrid(DataGridInterface $dataGrid)
+    {
+        $this->formName = $dataGrid->getName();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function bindData(ColumnTypeInterface $column, $data, $object, $index)
+    {
+        if ($column->getOption('editable') === false) {
+            return;
+        }
+
+        $formData = array();
+        switch ($column->getId()) {
+            case 'entity':
+                $relationField = $column->getOption('relation_field');
+                if (!isset($data[$relationField])) {
+                    return;
+                }
+
+                $formData[$relationField] = $data[$relationField];
+                break;
+
+            default:
+                $fieldMapping = $column->getOption('field_mapping');
+                foreach ($fieldMapping as $field) {
+                    if (!isset($data[$field])) {
+                        return;
+                    }
+
+                    $formData[$field] = $data[$field];
+                }
+        }
+
+        $form = $this->createForm($column, $index, $object);
+        $form->bind(array($index => $formData));
+        if ($form->isValid()) {
+            $data = $form->getData();
+            foreach ($data as $index => $fields) {
+                foreach ($fields as $field => $value) {
+                    $column->getDataMapper()->setData($field, $object, $value);
+                }
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildCellView(ColumnTypeInterface $column, CellViewInterface $view)
+    {
+        if (!$column->getOption('editable')) {
+            return;
+        }
+
+        $data = $view->getSource();
+        $index = $view->getAttribute('row');
+        $form = $this->createForm($column, $index, $data);
+
+        $view->setAttribute('form', $form->createView());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtendedColumnTypes()
+    {
+        return array(
+            'text',
+            'boolean',
+            'number',
+            'datetime',
+            'entity',
+            'gedmo_tree',
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initOptions(ColumnTypeInterface $column)
+    {
+        $column->getOptionsResolver()->setDefaults(array(
+            'editable' => false,
+            'form_options' => array(),
+            'form_type' => array(),
+        ));
+
+        $column->getOptionsResolver()->setAllowedTypes(array(
+            'editable' => 'bool',
+            'form_options' => 'array',
+            'form_type' => 'array',
+        ));
+    }
+
+    /**
+     * Create Form Objects for column and rowset index.
+     *
+     * @param \FSi\Component\DataGrid\Column\ColumnTypeInterface $column
+     * @param mixed $index
+     * @param mixed $data
+     */
+    private function createForm(ColumnTypeInterface $column, $index, $data)
+    {
+        $formId = implode(array($column->getName(),$column->getId(), $index));
+        if (array_key_exists($formId, $this->forms)) {
+            return $this->forms[$formId];
+        }
+
+        //Create fields array. There are column types like entity where field_mapping
+        //should not be used to build field array.
+        $fields = array();
+        switch ($column->getId()) {
+            case 'entity':
+                $field = array(
+                    'name' => $column->getOption('relation_field'),
+                    'type' => 'entity',
+                    'options' => array(),
+                );
+
+                $fields[$column->getOption('relation_field')] = $field;
+                break;
+
+            default:
+                foreach ($column->getOption('field_mapping') as $fieldName) {
+                    $field = array(
+                        'name' => $fieldName,
+                        'type' => null,
+                        'options' => array(),
+                    );
+                    $fields[$fieldName] = $field;
+                }
+        }
+
+        //Pass fields form options from column into $fields array.
+        $fieldsOptions = $column->getOption('form_options');
+        foreach ($fieldsOptions as $fieldName => $fieldOptions) {
+            if (array_key_exists($fieldName, $fields)) {
+                if (is_array($fieldOptions)) {
+                    $fields[$fieldName]['options'] = $fieldOptions;
+                }
+            }
+        }
+
+        //Pass fields form type from column into $fields array.
+        $fieldsTypes = $column->getOption('form_type');
+        foreach ($fieldsTypes as $fieldName => $fieldType) {
+            if (array_key_exists($fieldName, $fields)) {
+                if (is_string($fieldType)) {
+                    $fields[$fieldName]['type'] = $fieldType;
+                }
+            }
+        }
+
+        //Build data array, the data array holds data that should be passed into
+        //form elements.
+        $dataArray = array();
+        switch ($column->getId()) {
+            case 'datetime':
+                foreach ($fields as &$field) {
+                    $value = $column->getDataMapper()->getData($field['name'], $data);
+                    if (!isset($field['type'])) {
+                        $field['type'] = 'datetime';
+                    }
+                    if (is_numeric($value) && !isset($field['options']['input'])) {
+                        $field['options']['input'] = 'timestamp';
+                    }
+                    if (is_string($value) && !isset($field['options']['input'])) {
+                        $field['options']['input'] = 'string';
+                    }
+                    if (($value instanceof \DateTime) && !isset($field['options']['input'])) {
+                        $field['options']['input'] = 'datetime';
+                    }
+                    $dataArray[$field['name']] = $value;
+                }
+                break;
+
+            case 'entity':
+                    $value = $column->getDataMapper()->getData($column->getOption('relation_field'), $data);
+                    $dataArray[$column->getOption('relation_field')] = $value;
+                break;
+
+            default:
+                foreach ($fields as &$field) {
+                    $value = $column->getDataMapper()->getData($field['name'], $data);
+                    $dataArray[$field['name']] = $value;
+                }
+        }
+
+        //Create form builder.
+        try {
+            $formBuilder = $this->formFactory->createNamedBuilder(
+                $this->formName,
+                'collection',
+                array($index => $dataArray),
+                array(
+                    'type' => new RowType($fields),
+                    'csrf_protection' => false,
+                )
+            );
+        //Exception throwed when csrf_protection is not loaded.
+        } catch (InvalidOptionsException $exception) {
+            $formBuilder = $this->formFactory->createNamedBuilder(
+                $this->formName,
+                'collection',
+                array($index => $dataArray),
+                array('type' => new RowType($fields))
+            );
+        }
+
+        //Create Form.
+        $this->forms[$formId] = $formBuilder->getForm();
+
+        return $this->forms[$formId];
+    }
+}

--- a/DataGrid/Extension/ColumnTypeExtension/RowType.php
+++ b/DataGrid/Extension/ColumnTypeExtension/RowType.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\DataGridBundle\DataGrid\Extension\ColumnTypeExtension;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class RowType extends AbstractType
+{
+    /**
+     * @var array
+     */
+    protected $fields;
+
+    /**
+     * @param array $fields
+     */
+    public function __construct($fields = array())
+    {
+        $this->fields = $fields;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        foreach ($this->fields as $field) {
+            $builder->add($field['name'], $field['type'], $field['options']);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'row';
+    }
+}

--- a/DataGrid/Extension/DependencyInjectionExtension.php
+++ b/DataGrid/Extension/DependencyInjectionExtension.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\DataGridBundle\DataGrid\Extension;
+
+use FSi\Component\DataGrid\DataGridAbstractExtension;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class DependencyInjectionExtension extends DataGridAbstractExtension
+{
+    /**
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @var array
+     */
+    protected $columnServiceIds;
+
+    /**
+     * @var array
+     */
+    protected $columnExtensionServiceIds;
+
+    /**
+     * @var array
+     */
+    protected $gridSubscriberServiceIds;
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+     * @param array $columnServiceIds
+     * @param array $columnExtensionsServiceIds
+     * @param array $gridSubscriberServiceIds
+     */
+    public function __construct(
+        ContainerInterface $container,
+        array $columnServiceIds,
+        array $columnExtensionServiceIds,
+        array $gridSubscriberServiceIds
+    ) {
+        $this->container = $container;
+        $this->columnServiceIds = $columnServiceIds;
+        $this->columnExtensionServiceIds = $columnExtensionServiceIds;
+        $this->gridSubscriberServiceIds = $gridSubscriberServiceIds;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasColumnTypeExtensions($type)
+    {
+        foreach ($this->columnExtensionServiceIds as $alias => $extensionName) {
+            $extension = $this->container->get($this->columnExtensionServiceIds[$alias]);
+            $types = $extension->getExtendedColumnTypes();
+            if (in_array($type, $types)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasColumnType($type)
+    {
+        return isset($this->columnServiceIds[$type]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumnType($type)
+    {
+        if (!isset($this->columnServiceIds[$type])) {
+            throw new \InvalidArgumentException(sprintf('The column type "%s" is not registered with the service container.', $type));
+        }
+
+        $type = $this->container->get($this->columnServiceIds[$type]);
+
+        return $type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumnTypeExtensions($type)
+    {
+        $columnExtension = array();
+
+        foreach ($this->columnExtensionServiceIds as $alias => $extensionName) {
+            $extension = $this->container->get($this->columnExtensionServiceIds[$alias]);
+            $types = $extension->getExtendedColumnTypes();
+            if (in_array($type, $types)) {
+                $columnExtension[] = $extension;
+            }
+        }
+
+        return $columnExtension;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadSubscribers()
+    {
+        $subscribers = array();
+
+        foreach ($this->gridSubscriberServiceIds as $alias => $subscriberName) {
+            $subscriber = $this->container->get($this->gridSubscriberServiceIds[$alias]);
+            $subscribers[] = $subscriber;
+        }
+
+        return $subscribers;
+    }
+}

--- a/DataGrid/Extension/EventSubscriber/BindRequest.php
+++ b/DataGrid/Extension/EventSubscriber/BindRequest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\DataGridBundle\DataGrid\Extension\EventSubscriber;
+
+use FSi\Component\DataGrid\DataGridEventInterface;
+use FSi\Component\DataGrid\DataGridEvents;
+use FSi\Component\DataGrid\Exception\DataGridException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class BindRequest implements EventSubscriberInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(DataGridEvents::PRE_BIND_DATA => array('preBindData', 128));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preBindData(DataGridEventInterface $event)
+    {
+        $dataGrid = $event->getDataGrid();
+        $request = $event->getData();
+
+        if (!$request instanceof Request) {
+            return;
+        }
+
+        $name = $dataGrid->getName();
+
+        $default = array();
+
+        switch ($request->getMethod()) {
+            case 'POST':
+            case 'PUT':
+            case 'DELETE':
+            case 'PATCH':
+                $data = $request->request->get($name, $default);
+                break;
+            case 'GET':
+                $data = $request->query->get($name, $default);
+                break;
+
+            default:
+                throw new DataGridException(sprintf(
+                    'The request method "%s" is not supported',
+                    $request->getMethod()
+                ));
+        }
+
+        $event->setData($data);
+    }
+}

--- a/DataGrid/Extension/FormExtension.php
+++ b/DataGrid/Extension/FormExtension.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\DataGridBundle\DataGrid\Extension;
+
+use FSi\Component\DataGrid\DataGridAbstractExtension;
+use Symfony\Component\Form\FormFactoryInterface;
+
+class FormExtension extends DataGridAbstractExtension
+{
+    /**
+     * FormFactory used by extension to build forms.
+     *
+     * @var \Symfony\Component\Form\FormFactoryInterface
+     */
+    protected $formFactory;
+
+    /**
+     * @param \Symfony\Component\Form\FormFactoryInterface $formFactory
+     */
+    public function __construct(FormFactoryInterface $formFactory)
+    {
+        $this->formFactory = $formFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function loadColumnTypesExtensions()
+    {
+        return array(
+            new ColumnTypeExtension\FormExtension($this->formFactory),
+        );
+    }
+}

--- a/DataGrid/Extension/SymfonyExtension.php
+++ b/DataGrid/Extension/SymfonyExtension.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\DataGridBundle\DataGrid\Extension;
+
+use FSi\Component\DataGrid\DataGridAbstractExtension;
+use FSi\Bundle\DataGridBundle\DataGrid\Extension\EventSubscriber;
+use FSi\Bundle\DataGridBundle\DataGrid\Extension\ColumnType;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class SymfonyExtension extends DataGridAbstractExtension
+{
+    /**
+     * FormFactory used by extension to build forms.
+     *
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerInterface $formFactory
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function loadColumnTypes()
+    {
+        return array(
+            new ColumnType\Action($this->container),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function loadSubscribers()
+    {
+        return array(
+            new EventSubscriber\BindRequest(),
+        );
+    }
+}

--- a/Resources/config/datagrid.xml
+++ b/Resources/config/datagrid.xml
@@ -9,7 +9,7 @@
         <parameter key="datagrid.data_mapper.chain.class">FSi\Component\DataGrid\DataMapper\ChainMapper</parameter>
         <parameter key="datagrid.data_mapper.reflection.class">FSi\Component\DataGrid\DataMapper\ReflectionMapper</parameter>
         <parameter key="datagrid.data_mapper.property_accessor.class">FSi\Component\DataGrid\DataMapper\PropertyAccessorMapper</parameter>
-        <parameter key="datagrid.extension.class">FSi\Component\DataGrid\Extension\Symfony\DependencyInjectionExtension</parameter>
+        <parameter key="datagrid.extension.class">FSi\Bundle\DataGridBundle\DataGrid\Extension\DependencyInjectionExtension</parameter>
     </parameters>
 
     <services>
@@ -102,15 +102,15 @@
         <!-- GedmoExtension -->
 
         <!-- SymfonyExtension -->
-        <service id="datagrid.column.symfony.action" class="FSi\Component\DataGrid\Extension\Symfony\ColumnType\Action">
+        <service id="datagrid.column.symfony.action" class="FSi\Bundle\DataGridBundle\DataGrid\Extension\ColumnType\Action">
             <tag name="datagrid.column" alias="action" />
             <argument type="service" id="service_container"/>
         </service>
-        <service id="datagrid.column_extension.symfony.form" class="FSi\Component\DataGrid\Extension\Symfony\ColumnTypeExtension\FormExtension">
+        <service id="datagrid.column_extension.symfony.form" class="FSi\Bundle\DataGridBundle\DataGrid\Extension\ColumnTypeExtension\FormExtension">
             <tag name="datagrid.column_extension" alias="symfony.form"/>
             <argument type="service" id="form.factory" />
         </service>
-        <service id="datagrid.subscriber.symfony.bindrequest" class="FSi\Component\DataGrid\Extension\Symfony\EventSubscriber\BindRequest">
+        <service id="datagrid.subscriber.symfony.bindrequest" class="FSi\Bundle\DataGridBundle\DataGrid\Extension\EventSubscriber">
             <tag name="datagrid.subscriber" alias="symfony.form.bindrequest"/>
         </service>
         <service id="datagrid.column_extension.symfony.column.boolean" class="FSi\Bundle\DataGridBundle\DataGrid\Extension\View\ColumnTypeExtension\BooleanColumnExtension">

--- a/Tests/DataGrid/Extension/ColumnType/ActionTest.php
+++ b/Tests/DataGrid/Extension/ColumnType/ActionTest.php
@@ -1,0 +1,245 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\DataGridBundle\Tests\DataGrid\Extension\ColumnType;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use FSi\Bundle\DataGridBundle\DataGrid\Extension\ColumnType\Action;
+use FSi\Component\DataGrid\Extension\Core\ColumnTypeExtension\DefaultColumnOptionsExtension;
+
+class ActionTest extends \PHPUnit_Framework_TestCase
+{
+    private $container;
+    private $column;
+
+    protected function setUp()
+    {
+        if (!interface_exists('Symfony\Component\DependencyInjection\ContainerInterface')
+            || !interface_exists('Symfony\Component\Routing\RouterInterface')
+            || !class_exists('Symfony\Component\HttpFoundation\Request')) {
+            $this->markTestSkipped('Symfony Column Action require Symfony\Component\DependencyInjection\ContainerInterface interface.');
+        }
+
+        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+
+        $column = new Action($this->container);
+        $column->setName('action');
+        $column->initOptions();
+
+        $extension = new DefaultColumnOptionsExtension();
+        $extension->initOptions($column);
+
+        $this->column = $column;
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testFilterValueWrongActionsOptionType()
+    {
+        $this->column->setOption('actions', 'boo');
+        $this->column->filterValue(array());
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testFilterValueInvalidActionInActionsOption()
+    {
+        $this->column->setOption('actions', array('edit' => 'asdasd'));
+        $this->column->filterValue(array());
+    }
+
+    public function testFilterValueRequiredActionInActionsOption()
+    {
+        $self = $this;
+
+        $this->container->expects($this->any())
+            ->method('get')
+            ->will($this->returnCallback(function($serviceId) use ($self) {
+
+                if ($serviceId == 'router') {
+                    $router = $self->getMock('Symfony\Component\Routing\RouterInterface');
+                    $router->expects($self->once())
+                        ->method('generate')
+                        ->with('foo', array('redirect_uri' => 'http://example.com/?test=1&test=2'), false)
+                        ->will($self->returnValue('/test/bar?redirect_uri=' . urlencode(MyRequest::URI)));
+
+                    return $router;
+                }
+
+                if ($serviceId == 'request') {
+                    return new MyRequest();
+                }
+            }));
+
+        $column = new Action($this->container);
+        $column->setName('action');
+        $column->initOptions();
+
+        $extension = new DefaultColumnOptionsExtension();
+        $extension->initOptions($column);
+
+
+        $column->setOption('actions', array(
+            'edit' => array(
+                'route_name' => 'foo',
+                'absolute' => false
+            )
+        ));
+
+       $this->assertSame(
+           array(
+               'edit' => array(
+                   'url' => '/test/bar?redirect_uri=' . urlencode(MyRequest::URI),
+                   'content' => 'edit',
+                   'field_mapping_values' => array(
+                           'foo' => 'bar'
+                   ),
+                   'url_attr' => Array (
+                       'href' => '/test/bar?redirect_uri=http%3A%2F%2Fexample.com%2F%3Ftest%3D1%26test%3D2'
+                   )
+               )
+           ),
+           $column->filterValue(array(
+               'foo' => 'bar'
+           ))
+       );
+    }
+
+    public function testFilterValueAvailableActionInActionsOption()
+    {
+        $self = $this;
+
+        $this->container->expects($this->any())
+            ->method('get')
+            ->will($this->returnCallback(function($serviceId) use ($self) {
+                switch ($serviceId) {
+                    case 'router':
+                        $router = $self->getMock('Symfony\Component\Routing\RouterInterface');
+                        $router->expects($self->once())
+                            ->method('generate')
+                            ->with('foo', array('foo' => 'bar', 'redirect_uri' => 'http://example.com/?test=1&test=2'), true)
+                            ->will($self->returnValue('https://fsi.pl/test/bar?redirect_uri=' . urlencode(MyRequest::URI)));
+                        return $router;
+                        break;
+                    case 'request':
+                        return new MyRequest();
+                        break;
+                }
+            }));
+
+        $column = new Action($this->container);
+        $column->setName('action');
+        $column->initOptions();
+
+        $extension = new DefaultColumnOptionsExtension();
+        $extension->initOptions($column);
+
+        $column->setOption('field_mapping', array('foo'));
+        $column->setOption('actions', array(
+            'edit' => array(
+                'route_name' => 'foo',
+                'parameters_field_mapping' => array('foo' => 'foo'),
+                'absolute' => true
+            )
+        ));
+
+       $this->assertSame(
+           array(
+               'edit' => array(
+                   'url' => 'https://fsi.pl/test/bar?redirect_uri=' . urlencode(MyRequest::URI),
+                    'content' => 'edit',
+                   'field_mapping_values' => array(
+                           'foo' => 'bar'
+                   ),
+                   'url_attr' => array (
+                       'href' => 'https://fsi.pl/test/bar?redirect_uri=http%3A%2F%2Fexample.com%2F%3Ftest%3D1%26test%3D2'
+                   )
+               )
+           ),
+           $column->filterValue(array(
+               'foo' => 'bar'
+           ))
+       );
+    }
+
+
+    public function testFilterValueWithRedirectUriFalse()
+    {
+        $self = $this;
+
+        $this->container->expects($this->any())
+            ->method('get')
+            ->will($this->returnCallback(function($serviceId) use ($self) {
+                switch ($serviceId) {
+                    case 'router':
+                        $router = $self->getMock('Symfony\Component\Routing\RouterInterface');
+                        $router->expects($self->once())
+                            ->method('generate')
+                            ->with('foo', array(), false)
+                            ->will($self->returnValue('/test/bar'));
+
+                        return $router;
+                    break;
+                    case 'request':
+                        return new MyRequest();
+                    break;
+                }
+            }));
+
+        $column = new Action($this->container);
+        $column->setName('action');
+        $column->initOptions();
+
+        $extension = new DefaultColumnOptionsExtension();
+        $extension->initOptions($column);
+
+        $column->setOption('actions', array(
+            'edit' => array(
+                'route_name' => 'foo',
+                'absolute' => false,
+                'redirect_uri' => false
+            )
+        ));
+
+       $this->assertSame(
+           array(
+               'edit' => array(
+                   'url' => '/test/bar',
+                   'content' => 'edit',
+                   'field_mapping_values' => array(
+                       'foo' => 'bar'
+                   ),
+                   'url_attr' => array (
+                       'href' => '/test/bar'
+                   )
+               )
+           ),
+           $column->filterValue(array(
+               'foo' => 'bar'
+           ))
+       );
+    }
+}
+
+class MyRequest extends Request
+{
+    const URI = 'http://example.com/?test=1&test=2';
+
+    public function __construct()
+    {
+    }
+
+    public function getUri()
+    {
+        return urldecode(self::URI);
+    }
+}

--- a/Tests/DataGrid/Extension/ColumnTypeExtension/FormExtensionTest.php
+++ b/Tests/DataGrid/Extension/ColumnTypeExtension/FormExtensionTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\DataGridBundle\Tests\DataGrid\Extension\ColumnTypeExtension;
+
+use FSi\Bundle\DataGridBundle\DataGrid\Extension\ColumnTypeExtension\FormExtension;
+use Symfony\Component\Form\FormRegistry;
+use Symfony\Component\Form\FormFactory;
+use Symfony\Component\Form\ResolvedFormTypeFactory;
+use Symfony\Component\Form\Extension\Core\CoreExtension;
+use Symfony\Component\Form\Extension\Csrf\CsrfExtension;
+use FSi\Component\DataGrid\Tests\Fixtures\Entity;
+
+class FormExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    private $formFactory;
+
+    protected function setUp()
+    {
+        if (!class_exists('Symfony\Component\Form\FormRegistry')) {
+            $this->markTestSkipped('Symfony Column Extension require Symfony\Component\Form\FormRegistry class.');
+        }
+        $resolvedTypeFactory = new ResolvedFormTypeFactory();
+        $formRegistry = new FormRegistry(array(
+                new CoreExtension()
+            ),
+            $resolvedTypeFactory
+        );
+
+        $this->formFactory = new FormFactory($formRegistry, $resolvedTypeFactory);
+    }
+
+    public function testBindData()
+    {
+        $self = $this;
+
+        $dataGrid = $this->getMock('FSi\Component\DataGrid\DataGridInterface');
+        $dataGrid->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('grid'));
+
+        $extension = new FormExtension($this->formFactory);
+        $extension->setDataGrid($dataGrid);
+        $column = $this->getMock('FSi\Component\DataGrid\Column\ColumnTypeInterface');
+
+        $column->expects($this->any())
+            ->method('getId')
+            ->will($this->returnValue('text'));
+
+        $column->expects($this->any())
+            ->method('getDataMapper')
+            ->will($this->returnCallback(function() use ($self) {
+                $dataMapper = $self->getMock('FSi\Component\DataGrid\DataMapper\DataMapperInterface');
+                $dataMapper->expects($self->any())
+                    ->method('getData')
+                    ->will($self->returnCallback(function($field, $object){
+                        $method = 'get' . ucfirst($field);
+                        return $object->$method();
+                    }));
+
+                $dataMapper->expects($self->any())
+                    ->method('setData')
+                    ->will($self->returnCallback(function($field, $object, $value){
+                        $method = 'set' . ucfirst($field);
+                        return $object->$method($value);
+                    }));
+
+
+                return $dataMapper;
+            }));
+
+        $column->expects($this->any())
+            ->method('getOption')
+             ->will($this->returnCallback(function($option){
+                 switch($option) {
+                     case 'field_mapping':
+                        return array('name', 'author');
+                     break;
+                     case 'editable':
+                         return true;
+                     break;
+                     case 'form_options':
+                         return array();
+                     break;
+                     case 'form_type':
+                         return array(
+                             'name' => array(
+                                 'type' => 'text'
+                             ),
+                             'author' => array(
+                                 'type' => 'text'
+                             )
+                         );
+                     break;
+                 }
+             }));
+
+        $object = new Entity('old_name');
+        $data = array(
+            'name' => 'object',
+            'author' => 'norbert@fsi.pl',
+            'invalid_data' => 'test'
+        );
+
+        $extension->bindData($column, $data, $object, 1);
+
+        $this->assertSame($object->getAuthor(), 'norbert@fsi.pl');
+        $this->assertSame($object->getName(), 'object');
+    }
+}

--- a/Tests/DataGrid/Extension/EventSubscriber/BindRequestTest.php
+++ b/Tests/DataGrid/Extension/EventSubscriber/BindRequestTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\DataGridBundle\Tests\DataGrid\Extension\EventSubscriber;
+
+use FSi\Bundle\DataGridBundle\DataGrid\Extension\EventSubscriber\BindRequest;
+
+class BindRequestTest extends \PHPUnit_Framework_TestCase
+{
+    public function testPreBindDataWithoutRequestObject()
+    {
+        $event = $this->getMock('FSi\Component\DataGrid\DataGridEventInterface');
+        $event->expects($this->never())
+            ->method('setData');
+
+        $subscriber = new BindRequest();
+
+        $subscriber->preBindData($event);
+    }
+
+    public function testPreBindDataPOST()
+    {
+        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
+            $this->markTestSkipped('Symfony Column Extension require Symfony\Component\HttpFoundation\Request class.');
+        }
+
+        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $request->expects($this->once())
+             ->method('getMethod')
+             ->will($this->returnValue('POST'));
+
+        $requestBag = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $requestBag->expects($this->once())
+            ->method('get')
+            ->with('grid', array())
+            ->will($this->returnValue(array('foo' => 'bar')));
+
+        $request->request = $requestBag;
+
+        $grid = $this->getMock('FSi\Component\DataGrid\DataGridInterface');
+        $grid->expects($this->once())
+             ->method('getName')
+             ->will($this->returnValue('grid'));
+
+        $event = $this->getMock('FSi\Component\DataGrid\DataGridEventInterface');
+        $event->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($request));
+
+        $event->expects($this->once())
+            ->method('setData')
+            ->with(array('foo' => 'bar'));
+
+        $event->expects($this->once())
+            ->method('getDataGrid')
+            ->will($this->returnValue($grid));
+
+        $subscriber = new BindRequest();
+
+        $subscriber->preBindData($event);
+    }
+
+    public function testPreBindDataGET()
+    {
+        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
+            $this->markTestSkipped('Symfony Column Extension require Symfony\Component\HttpFoundation\Request class.');
+        }
+
+        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $request->expects($this->once())
+             ->method('getMethod')
+             ->will($this->returnValue('GET'));
+
+        $queryBag = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $queryBag->expects($this->once())
+            ->method('get')
+            ->with('grid', array())
+            ->will($this->returnValue(array('foo' => 'bar')));
+
+        $request->query = $queryBag;
+
+        $grid = $this->getMock('FSi\Component\DataGrid\DataGridInterface');
+        $grid->expects($this->once())
+             ->method('getName')
+             ->will($this->returnValue('grid'));
+
+        $event = $this->getMock('FSi\Component\DataGrid\DataGridEventInterface');
+        $event->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($request));
+
+        $event->expects($this->once())
+            ->method('setData')
+            ->with(array('foo' => 'bar'));
+
+        $event->expects($this->once())
+            ->method('getDataGrid')
+            ->will($this->returnValue($grid));
+
+        $subscriber = new BindRequest();
+
+        $subscriber->preBindData($event);
+    }
+}

--- a/Tests/DataGrid/Extension/FormExtensionTest.php
+++ b/Tests/DataGrid/Extension/FormExtensionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\DataGridBundle\Tests\DataGrid\Extension;
+
+use FSi\Bundle\DataGridBundle\DataGrid\Extension\FormExtension;
+
+class FormExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSymfonyFormExtension()
+    {
+        if (!class_exists('Symfony\Component\Form\FormFactory')) {
+            $this->markTestSkipped('Symfony\Component\Form\FormFactoryis required for testSymfonyFormExtension');
+        }
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $extension = new FormExtension($formFactory);
+
+        $this->assertFalse($extension->hasColumnType('foo'));
+        $this->assertTrue($extension->hasColumnTypeExtensions('text'));
+    }
+}

--- a/Tests/DataGrid/Extension/SymfonyExtensionTest.php
+++ b/Tests/DataGrid/Extension/SymfonyExtensionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\DataGridBundle\Tests\DataGrid\Extension;
+
+use FSi\Bundle\DataGridBundle\DataGrid\Extension\SymfonyExtension;
+
+class SymfonyExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSymfonyExtension()
+    {
+        if (!interface_exists('Symfony\Component\DependencyInjection\ContainerInterface')) {
+            $this->markTestSkipped('Symfony\Component\DependencyInjection\ContainerInterface required for testSymfonyExtension');
+        }
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $extension = new SymfonyExtension($container);
+
+        $this->assertTrue($extension->hasColumnType('action'));
+    }
+}

--- a/Tests/DataGrid/Extension/View/ColumnTypeExtension/BooleanColumnExtensionTest.php
+++ b/Tests/DataGrid/Extension/View/ColumnTypeExtension/BooleanColumnExtensionTest.php
@@ -11,7 +11,7 @@ namespace FSi\Bundle\DataGridBundle\Tests\DataGrid\Extension\View\ColumnTypeExte
 
 use FSi\Component\DataGrid\Extension\Core\ColumnType\Boolean;
 use FSi\Bundle\DataGridBundle\DataGrid\Extension\View\ColumnTypeExtension\BooleanColumnExtension;
-use FSi\Component\DataGrid\Extension\Symfony\ColumnTypeExtension\FormExtension;
+use FSi\Bundle\DataGridBundle\DataGrid\Extension\ColumnTypeExtension\FormExtension;
 
 class BooleanColumnExtensionTest extends \PHPUnit_Framework_TestCase
 {

--- a/Tests/Double/KernelStub.php
+++ b/Tests/Double/KernelStub.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace FSi\Bundle\DataGridBundle\Tests\Double;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class KernelStub implements KernelInterface
+{
+    private $bundles;
+
+    public function __construct(array $bundles = array())
+    {
+        foreach($bundles as $bundle) {
+            $this->bundles[$bundle] = new StubBundle($bundle);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true)
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerBundles()
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function boot()
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function shutdown()
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBundles()
+    {
+        return $this->bundles;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isClassInActiveBundle($class)
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBundle($name, $first = true)
+    {
+        return $this->bundles[$name];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function locateResource($name, $dir = null, $first = true)
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEnvironment()
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isDebug()
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRootDir()
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContainer()
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStartTime()
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCacheDir()
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLogDir()
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCharset()
+    {
+        
+    }
+}

--- a/Tests/Double/StubBundle.php
+++ b/Tests/Double/StubBundle.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace FSi\Bundle\DataGridBundle\Tests\Double;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+class StubBundle implements BundleInterface
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @param $name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function boot()
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function shutdown()
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContainerExtension()
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNamespace()
+    {
+        
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPath()
+    {
+        return sprintf('%s/../Fixtures/%s', __DIR__, $this->name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        
+    }
+}


### PR DESCRIPTION
this moves extensions from
`FSi\Component\DataGrid\Extension\Symfony` to
`FSi\Bundle\DataGridBundle\DataGrid\Extension` namespace