### PR TITLE
[PoC] DataGrid yml configurations allow imports

### DIFF
--- a/DataGrid/Extension/Configuration/EventSubscriber/ConfigurationBuilder.php
+++ b/DataGrid/Extension/Configuration/EventSubscriber/ConfigurationBuilder.php
@@ -9,23 +9,22 @@
 
 namespace FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\EventSubscriber;
 
-use FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\Loader\YamlFileLoader;
+use FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\Loader\FileLoader;
 use FSi\Component\DataGrid\DataGridEventInterface;
 use FSi\Component\DataGrid\DataGridEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\KernelInterface;
 
 class ConfigurationBuilder implements EventSubscriberInterface
 {
     /**
-     * @var \FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\Loader\YamlFileLoader
+     * @var \FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\Loader\FileLoader
      */
     protected $fileLoader;
 
     /**
-     * @param KernelInterface $kernel
+     * @param \FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\Loader\FileLoader $fileLoader
      */
-    function __construct(YamlFileLoader $fileLoader)
+    function __construct(FileLoader $fileLoader)
     {
         $this->fileLoader = $fileLoader;
     }
@@ -44,9 +43,7 @@ class ConfigurationBuilder implements EventSubscriberInterface
     public function readConfiguration(DataGridEventInterface $event)
     {
         $dataGrid = $event->getDataGrid();
-
         $this->fileLoader->setDataGrid($dataGrid);
-
         $this->fileLoader->load($dataGrid->getName() . '.yml');
     }
 }

--- a/DataGrid/Extension/Configuration/EventSubscriber/ConfigurationBuilder.php
+++ b/DataGrid/Extension/Configuration/EventSubscriber/ConfigurationBuilder.php
@@ -9,26 +9,25 @@
 
 namespace FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\EventSubscriber;
 
+use FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\Loader\YamlFileLoader;
 use FSi\Component\DataGrid\DataGridEventInterface;
 use FSi\Component\DataGrid\DataGridEvents;
-use FSi\Component\DataGrid\DataGridInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Component\Yaml\Parser;
 
 class ConfigurationBuilder implements EventSubscriberInterface
 {
     /**
-     * @var \Symfony\Component\HttpKernel\KernelInterface
+     * @var \FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\Loader\YamlFileLoader
      */
-    protected $kernel;
+    protected $fileLoader;
 
     /**
      * @param KernelInterface $kernel
      */
-    function __construct(KernelInterface $kernel)
+    function __construct(YamlFileLoader $fileLoader)
     {
-        $this->kernel = $kernel;
+        $this->fileLoader = $fileLoader;
     }
 
     /**
@@ -45,58 +44,9 @@ class ConfigurationBuilder implements EventSubscriberInterface
     public function readConfiguration(DataGridEventInterface $event)
     {
         $dataGrid = $event->getDataGrid();
-        $dataGridConfiguration = array();
-        foreach ($this->kernel->getBundles() as $bundle) {
-            if ($this->hasDataGridConfiguration($bundle->getPath(), $dataGrid->getName())) {
-                $configuration = $this->getDataGridConfiguration($bundle->getPath(), $dataGrid->getName());
 
-                if (is_array($configuration)) {
-                    $dataGridConfiguration = $configuration;
-                }
-            }
-        }
+        $this->fileLoader->setDataGrid($dataGrid);
 
-        if (count($dataGridConfiguration)) {
-            $this->buildConfiguration($dataGrid, $dataGridConfiguration);
-        }
-    }
-
-    /**
-     * @param string $bundlePath
-     * @param string $dataGridName
-     * @return bool
-     */
-    protected function hasDataGridConfiguration($bundlePath, $dataGridName)
-    {
-        return file_exists(sprintf($bundlePath . '/Resources/config/datagrid/%s.yml', $dataGridName));
-    }
-
-    /**
-     * @param string $bundlePath
-     * @param string $dataGridName
-     * @return mixed
-     */
-    protected function getDataGridConfiguration($bundlePath, $dataGridName)
-    {
-        $yamlParser = new Parser();
-        return $yamlParser->parse(file_get_contents(sprintf($bundlePath . '/Resources/config/datagrid/%s.yml', $dataGridName)));
-    }
-
-    /**
-     * @param DataGridInterface $dataGrid
-     * @param array $configuration
-     */
-    protected function buildConfiguration(DataGridInterface $dataGrid, array $configuration)
-    {
-        foreach ($configuration['columns'] as $name => $column) {
-            $type = array_key_exists('type', $column)
-                ? $column['type']
-                : 'text';
-            $options = array_key_exists('options', $column)
-                ? $column['options']
-                : array();
-
-            $dataGrid->addColumn($name, $type, $options);
-        }
+        $this->fileLoader->load($dataGrid->getName() . '.yml');
     }
 }

--- a/DataGrid/Extension/Configuration/Loader/FileLoader.php
+++ b/DataGrid/Extension/Configuration/Loader/FileLoader.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\Loader;
+
+use FSi\Component\DataGrid\DataGridInterface;
+use Symfony\Component\Config\Loader\FileLoader as BaseFileLoader;
+
+abstract class FileLoader extends BaseFileLoader
+{
+    /**
+     * @var \FSi\Component\DataGrid\DataGridInterface
+     */
+    protected $dataGrid;
+
+    /**
+     * @param \FSi\Component\DataGrid\DataGridInterface $dataGrid
+     */
+    public function setDataGrid(DataGridInterface $dataGrid)
+    {
+        $this->dataGrid = $dataGrid;
+    }
+}

--- a/DataGrid/Extension/Configuration/Loader/YamlFileLoader.php
+++ b/DataGrid/Extension/Configuration/Loader/YamlFileLoader.php
@@ -9,8 +9,6 @@
 
 namespace FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\Loader;
 
-use FSi\Component\DataGrid\DataGridInterface;
-use Symfony\Component\Config\Loader\FileLoader;
 use Symfony\Component\Yaml\Parser as YamlParser;
 
 class YamlFileLoader extends FileLoader
@@ -21,23 +19,7 @@ class YamlFileLoader extends FileLoader
     private $yamlParser;
 
     /**
-     * @var \FSi\Component\DataGrid\DataGridInterface
-     */
-    private $dataGrid;
-
-    /**
-     * @param \FSi\Component\DataGrid\DataGridInterface $dataGrid
-     */
-    public function setDataGrid(DataGridInterface $dataGrid)
-    {
-        $this->dataGrid = $dataGrid;
-    }
-
-    /**
-     * Loads a resource.
-     *
-     * @param mixed $file The resource
-     * @param string $type The resource type
+     * @inheritdoc
      */
     public function load($file, $type = null)
     {
@@ -59,12 +41,7 @@ class YamlFileLoader extends FileLoader
     }
 
     /**
-     * Returns true if this class supports the given resource.
-     *
-     * @param mixed $resource A resource
-     * @param string $type The resource type
-     *
-     * @return bool    true if this class supports the given resource, false otherwise
+     * @inheritdoc
      */
     public function supports($resource, $type = null)
     {
@@ -72,10 +49,7 @@ class YamlFileLoader extends FileLoader
     }
 
     /**
-     * Loads a YAML file.
-     *
      * @param string $file
-     *
      * @return array The file content
      */
     private function loadFile($file)
@@ -96,9 +70,7 @@ class YamlFileLoader extends FileLoader
     }
 
     /**
-     * Parses all imports
-     *
-     * @param array  $content
+     * @param array $content
      * @param string $file
      */
     private function parseImports($content, $file)

--- a/DataGrid/Extension/Configuration/Loader/YamlFileLoader.php
+++ b/DataGrid/Extension/Configuration/Loader/YamlFileLoader.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\Loader;
+
+use FSi\Component\DataGrid\DataGridInterface;
+use Symfony\Component\Config\Loader\FileLoader;
+use Symfony\Component\Yaml\Parser as YamlParser;
+
+class YamlFileLoader extends FileLoader
+{
+    /**
+     * @var \Symfony\Component\Yaml\Parser
+     */
+    private $yamlParser;
+
+    /**
+     * @var \FSi\Component\DataGrid\DataGridInterface
+     */
+    private $dataGrid;
+
+    /**
+     * @param \FSi\Component\DataGrid\DataGridInterface $dataGrid
+     */
+    public function setDataGrid(DataGridInterface $dataGrid)
+    {
+        $this->dataGrid = $dataGrid;
+    }
+
+    /**
+     * Loads a resource.
+     *
+     * @param mixed $file The resource
+     * @param string $type The resource type
+     */
+    public function load($file, $type = null)
+    {
+        if (null === $this->dataGrid) {
+            throw new \BadMethodCallException(sprintf('setDataGrid() must be called before load() on %s', __CLASS__));
+        }
+
+        $path = $this->locator->locate($file);
+
+        $content = $this->loadFile($path);
+
+        if (null === $content) {
+            return;
+        }
+
+        $this->parseImports($content, $path);
+
+        $this->addColumns($content);
+    }
+
+    /**
+     * Returns true if this class supports the given resource.
+     *
+     * @param mixed $resource A resource
+     * @param string $type The resource type
+     *
+     * @return bool    true if this class supports the given resource, false otherwise
+     */
+    public function supports($resource, $type = null)
+    {
+        return is_string($resource) && 'yml' === pathinfo($resource, PATHINFO_EXTENSION);
+    }
+
+    /**
+     * Loads a YAML file.
+     *
+     * @param string $file
+     *
+     * @return array The file content
+     */
+    private function loadFile($file)
+    {
+        if (!stream_is_local($file)) {
+            throw new \InvalidArgumentException(sprintf('This is not a local file "%s".', $file));
+        }
+
+        if (!file_exists($file)) {
+            throw new \InvalidArgumentException(sprintf('The config file "%s" is not valid.', $file));
+        }
+
+        if (null === $this->yamlParser) {
+            $this->yamlParser = new YamlParser();
+        }
+
+        return $this->yamlParser->parse(file_get_contents($file));
+    }
+
+    /**
+     * Parses all imports
+     *
+     * @param array  $content
+     * @param string $file
+     */
+    private function parseImports($content, $file)
+    {
+        if (!isset($content['imports'])) {
+            return;
+        }
+
+        foreach ($content['imports'] as $import) {
+            $this->setCurrentDir(dirname($file));
+            $this->import($import['resource'], null, isset($import['ignore_errors']) ? (bool) $import['ignore_errors'] : false, $file);
+        }
+    }
+
+    /**
+     * @param array $content
+     */
+    private function addColumns(array $content)
+    {
+        foreach ($content['columns'] as $name => $column) {
+            $type = array_key_exists('type', $column)
+                ? $column['type']
+                : 'text';
+            $options = array_key_exists('options', $column)
+                ? $column['options']
+                : array();
+
+            $this->dataGrid->addColumn($name, $type, $options);
+        }
+    }
+}

--- a/DataGrid/Extension/Configuration/Locator/FileLocator.php
+++ b/DataGrid/Extension/Configuration/Locator/FileLocator.php
@@ -20,6 +20,7 @@ class FileLocator extends BaseFileLocator
 
     /**
      * @param KernelInterface $kernel A KernelInterface instance
+     * @param string $path
      * @param string $bundleRelativePath
      */
     public function __construct(KernelInterface $kernel, $path, $bundleRelativePath)
@@ -83,14 +84,7 @@ class FileLocator extends BaseFileLocator
     {
         $fileParts = explode(':', $file, 2);
 
-        return implode('', array(
-            '@',
-            $fileParts[0],
-            DIRECTORY_SEPARATOR,
-            $this->bundleRelativePath,
-            DIRECTORY_SEPARATOR,
-            $fileParts[1]
-        ));
+        return sprintf('@%s/%s/%s', $fileParts[0], $this->bundleRelativePath, $fileParts[1]);
     }
 
     /**
@@ -108,6 +102,6 @@ class FileLocator extends BaseFileLocator
      */
     private function prependBundleRelativePath($file)
     {
-        return $this->bundleRelativePath . DIRECTORY_SEPARATOR . $file;
+        return sprintf('%s/%s', $this->bundleRelativePath, $file);
     }
 }

--- a/DataGrid/Extension/Configuration/Locator/FileLocator.php
+++ b/DataGrid/Extension/Configuration/Locator/FileLocator.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\Locator;
+
+use Symfony\Component\Config\FileLocator as BaseFileLocator;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class FileLocator extends BaseFileLocator
+{
+    private $kernel;
+    private $bundleRelativePath;
+    private $path;
+
+    /**
+     * @param KernelInterface $kernel A KernelInterface instance
+     * @param string $bundleRelativePath
+     */
+    public function __construct(KernelInterface $kernel, $path, $bundleRelativePath)
+    {
+        $this->kernel = $kernel;
+        $this->bundleRelativePath = $bundleRelativePath;
+        $this->path = $path;
+
+        $paths = array($path);
+        $paths = array_merge($paths, $this->getBundlesPaths());
+
+        parent::__construct($paths);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function locate($file, $currentPath = null, $first = true)
+    {
+        if ($this->isFileInBundle($file)) {
+            return $this->kernel->locateResource(
+                $this->getFilePathInBundle($file),
+                $this->path,
+                $first
+            );
+        }
+
+        if (!$this->isFileGlobal($file, $currentPath)) {
+            $file = $this->prependBundleRelativePath($file);
+        }
+
+        return parent::locate($file, $currentPath, $first);
+    }
+
+    /**
+     * @return array
+     */
+    private function getBundlesPaths()
+    {
+        $paths = array();
+        foreach (array_reverse($this->kernel->getBundles()) as $bundle) {
+            $paths[] = $bundle->getPath();
+        }
+        return $paths;
+    }
+
+    /**
+     * @param $file
+     * @return bool
+     */
+    private function isFileInBundle($file)
+    {
+        return strpos($file, ':') !== false;
+    }
+
+    /**
+     * @param $file
+     * @return string
+     */
+    private function getFilePathInBundle($file)
+    {
+        $fileParts = explode(':', $file, 2);
+
+        return implode('', array(
+            '@',
+            $fileParts[0],
+            DIRECTORY_SEPARATOR,
+            $this->bundleRelativePath,
+            DIRECTORY_SEPARATOR,
+            $fileParts[1]
+        ));
+    }
+
+    /**
+     * @param $file
+     * @return bool
+     */
+    private function isFileGlobal($file, $currentPath)
+    {
+        return $file[0] === '/' || strpos($currentPath, $this->bundleRelativePath) !== false;
+    }
+
+    /**
+     * @param $file
+     * @return string
+     */
+    private function prependBundleRelativePath($file)
+    {
+        return $this->bundleRelativePath . DIRECTORY_SEPARATOR . $file;
+    }
+}

--- a/DataGrid/Extension/Configuration/Locator/FileLocator.php
+++ b/DataGrid/Extension/Configuration/Locator/FileLocator.php
@@ -48,7 +48,7 @@ class FileLocator extends BaseFileLocator
             );
         }
 
-        if (!$this->isFileGlobal($file, $currentPath)) {
+        if (!$this->isFileGlobal($file) && !$this->isPathInBundle($currentPath)) {
             $file = $this->prependBundleRelativePath($file);
         }
 
@@ -82,18 +82,27 @@ class FileLocator extends BaseFileLocator
      */
     private function getFilePathInBundle($file)
     {
-        $fileParts = explode(':', $file, 2);
+        list($bundleName, $fileName) = explode(':', $file, 2);
 
-        return sprintf('@%s/%s/%s', $fileParts[0], $this->bundleRelativePath, $fileParts[1]);
+        return sprintf('@%s/%s/%s', $bundleName, $this->bundleRelativePath, $fileName);
     }
 
     /**
-     * @param $file
+     * @param string $file
      * @return bool
      */
-    private function isFileGlobal($file, $currentPath)
+    private function isFileGlobal($file)
     {
-        return $file[0] === '/' || strpos($currentPath, $this->bundleRelativePath) !== false;
+        return $file[0] === '/';
+    }
+
+    /**
+     * @param string $path
+     * @return bool
+     */
+    private function isPathInBundle($path)
+    {
+        return strpos($path, $this->bundleRelativePath) !== false;
     }
 
     /**

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -25,10 +25,31 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->booleanNode('yaml_configuration')->defaultTrue()->end()
                 ->arrayNode('twig')
+                    ->beforeNormalization()
+                        ->ifTrue(function ($v) { return isset($v['template']); })
+                        ->then(function ($v) {
+                            trigger_error('The fsi_data_grid.twig.template configuration key is deprecated since version 1.1 and will be removed in 1.2. Use the fsi_data_grid.twig.themes configuration key instead.', E_USER_DEPRECATED);
+                            return $v;
+                        })
+                    ->end()
+                    ->validate()
+                        ->ifTrue(function ($v) {
+                            return isset($v['template']) && ($v['template'] !== null);
+                        })
+                        ->then(function ($v) {
+                            $v['themes'] = array($v['template']);
+                            unset($v['template']);
+                            return $v;
+                        })
+                    ->end()
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->booleanNode('enabled')->defaultTrue()->end()
-                        ->scalarNode('template')->defaultValue('datagrid.html.twig')->end()
+                        ->scalarNode('template')->end()
+                        ->arrayNode('themes')
+                            ->prototype('scalar')->end()
+                            ->defaultValue(array('datagrid.html.twig'))
+                        ->end()
                     ->end()
                 ->end()
             ->end()

--- a/DependencyInjection/FSIDataGridExtension.php
+++ b/DependencyInjection/FSIDataGridExtension.php
@@ -40,6 +40,6 @@ class FSIDataGridExtension extends Extension
     public function registerTwigConfiguration(array $config, ContainerBuilder $container, XmlFileLoader $loader)
     {
         $loader->load('twig.xml');
-        $container->setParameter('datagrid.twig.template', $config['template']);
+        $container->setParameter('datagrid.twig.themes', $config['themes']);
     }
 }

--- a/Resources/config/datagrid_yaml_configuration.xml
+++ b/Resources/config/datagrid_yaml_configuration.xml
@@ -6,12 +6,23 @@
 
     <parameters>
         <parameter key="datagrid.subscriber.configuration.configuration_builder.class">FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\EventSubscriber\ConfigurationBuilder</parameter>
+        <parameter key="datagrid.configuration.loader.yaml_file_loader.class">FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\Loader\YamlFileLoader</parameter>
+        <parameter key="datagrid.configuration.file_locator.class">FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\Locator\FileLocator</parameter>
     </parameters>
 
     <services>
+        <service id="datagrid.configuration.file_locator" class="%datagrid.configuration.file_locator.class%">
+            <argument type="service" id="kernel" />
+            <argument type="string">Resources/config/datagrid</argument>
+        </service>
+
+        <service id="datagrid.configuration.loader.yaml_file_loader" class="%datagrid.configuration.loader.yaml_file_loader.class%">
+            <argument type="service" id="datagrid.configuration.file_locator" />
+        </service>
+
         <service id="datagrid.subscriber.configuration.configuration_builder" class="%datagrid.subscriber.configuration.configuration_builder.class%">
             <tag name="datagrid.subscriber" alias="configuration.configuration_builder"/>
-            <argument type="service" id="kernel" />
+            <argument type="service" id="datagrid.configuration.loader.yaml_file_loader" />
         </service>
     </services>
 </container>

--- a/Resources/config/datagrid_yaml_configuration.xml
+++ b/Resources/config/datagrid_yaml_configuration.xml
@@ -13,6 +13,7 @@
     <services>
         <service id="datagrid.configuration.file_locator" class="%datagrid.configuration.file_locator.class%">
             <argument type="service" id="kernel" />
+            <argument type="string">%kernel.root_dir%/Resources</argument>
             <argument type="string">Resources/config/datagrid</argument>
         </service>
 

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -10,7 +10,7 @@
     <services>
         <service id="datagrid.twig.extension" class="%datagrid.twig.extension.class%" public="false">
             <tag name="twig.extension" />
-            <argument>%datagrid.twig.template%</argument>
+            <argument>%datagrid.twig.themes%</argument>
         </service>
     </services>
 

--- a/Tests/DataGrid/Extension/Configuration/EventSubscriber/ConfigurationBuilderTest.php
+++ b/Tests/DataGrid/Extension/Configuration/EventSubscriber/ConfigurationBuilderTest.php
@@ -19,6 +19,16 @@ use FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\EventSubscriber\C
 class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * @var string
+     */
+    protected static $fixtureAppPath;
+
+    /**
+     * @var string
+     */
+    protected static $datagridConfigRelativePath = 'Resources/config/datagrid';
+
+    /**
      * @var KernelInterface
      */
     protected $kernel;
@@ -31,6 +41,7 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->kernel = $this->getMock('Symfony\Component\HttpKernel\Kernel', array(), array('dev', true));
+        self::$fixtureAppPath = __DIR__ . '/../../../../Fixtures';
     }
 
     public function testSubscribedEvents()
@@ -53,12 +64,7 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
         $this->kernel->expects($this->once())
             ->method('getBundles')
             ->will($this->returnCallback(function() use ($self) {
-                $bundle = $self->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
-                $bundle->expects($self->any())
-                    ->method('getPath')
-                    ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/FooBundle'));
-
-                return array($bundle);
+                return array($self->getBundleMock('FooBundle'));
             }));
 
         $this->initSubscriber();
@@ -86,18 +92,9 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
         $this->kernel->expects($this->once())
             ->method('getBundles')
             ->will($this->returnCallback(function() use ($self) {
-                $fooBundle = $self->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
-                $fooBundle->expects($self->any())
-                    ->method('getPath')
-                    ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/FooBundle'));
-
-                $barBundle = $self->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
-                $barBundle->expects($self->any())
-                    ->method('getPath')
-                    ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/BarBundle'));
                 return array(
-                    $fooBundle,
-                    $barBundle
+                    $self->getBundleMock('FooBundle'),
+                    $self->getBundleMock('BarBundle')
                 );
             }));
 
@@ -134,14 +131,7 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
         $this->kernel->expects($this->once())
             ->method('getBundles')
             ->will($this->returnCallback(function() use ($self) {
-                $barBundle = $self->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
-                $barBundle->expects($self->any())
-                    ->method('getPath')
-                    ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/BarBundle'));
-
-                return array(
-                    $barBundle
-                );
+                return array($self->getBundleMock('BarBundle'));
             }));
 
         $this->initSubscriber();
@@ -190,26 +180,16 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
         $this->kernel->expects($this->once())
             ->method('getBundles')
             ->will($this->returnCallback(function() use ($self) {
-                $barBundle = $self->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
-                $barBundle->expects($self->any())
-                    ->method('getPath')
-                    ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/BarBundle'));
-
-                $bazBundle = $self->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
-                $bazBundle->expects($self->any())
-                    ->method('getPath')
-                    ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/BazBundle'));
-
                 return array(
-                    $barBundle,
-                    $bazBundle
+                    $self->getBundleMock('BarBundle'),
+                    $self->getBundleMock('BazBundle')
                 );
             }));
 
-        $this->kernel->expects($self->once())
+        $this->kernel->expects($this->once())
             ->method('locateResource')
-            ->with('@BarBundle/Resources/config/datagrid/news.yml', '', false)
-            ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/BarBundle/Resources/config/datagrid/news.yml'));
+            ->with('@BarBundle/' . self::$datagridConfigRelativePath . '/news.yml', '', false)
+            ->will($this->returnValue(self::$fixtureAppPath . '/BarBundle/' . self::$datagridConfigRelativePath . '/news.yml'));
 
         $this->initSubscriber();
 
@@ -257,32 +237,17 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
         $this->kernel->expects($this->once())
             ->method('getBundles')
             ->will($this->returnCallback(function() use ($self) {
-                $fooBundle = $self->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
-                $fooBundle->expects($self->any())
-                    ->method('getPath')
-                    ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/FooBundle'));
-
-                $barBundle = $self->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
-                $barBundle->expects($self->any())
-                    ->method('getPath')
-                    ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/BarBundle'));
-
-                $bazBundle = $self->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
-                $bazBundle->expects($self->any())
-                    ->method('getPath')
-                    ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/BazBundle'));
-
                 return array(
-                    $barBundle,
-                    $bazBundle,
-                    $fooBundle,
+                    $self->getBundleMock('BarBundle'),
+                    $self->getBundleMock('BazBundle'),
+                    $self->getBundleMock('FooBundle')
                 );
             }));
 
-        $this->kernel->expects($self->once())
+        $this->kernel->expects($this->once())
             ->method('locateResource')
-            ->with('@BarBundle/Resources/config/datagrid/extended_news.yml', '', false)
-            ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/BarBundle/Resources/config/datagrid/extended_news.yml'));
+            ->with('@BarBundle/' . self::$datagridConfigRelativePath . '/extended_news.yml', '', false)
+            ->will($this->returnValue(self::$fixtureAppPath . '/BarBundle/' . self::$datagridConfigRelativePath . '/extended_news.yml'));
 
         $this->initSubscriber();
 
@@ -341,8 +306,18 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $this->subscriber = new ConfigurationBuilder(
             new YamlFileLoader(
-                new FileLocator($this->kernel, '', 'Resources/config/datagrid')
+                new FileLocator($this->kernel, '', self::$datagridConfigRelativePath)
             )
         );
+    }
+
+    protected function getBundleMock($bundleName)
+    {
+        $bundleMock = $this->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
+        $bundleMock->expects($this->any())
+            ->method('getPath')
+            ->will($this->returnValue(self::$fixtureAppPath . '/' . $bundleName));
+
+        return $bundleMock;
     }
 }

--- a/Tests/DataGrid/Extension/Configuration/EventSubscriber/ConfigurationBuilderTest.php
+++ b/Tests/DataGrid/Extension/Configuration/EventSubscriber/ConfigurationBuilderTest.php
@@ -9,6 +9,8 @@
 
 namespace FSi\Bundle\DataGridBundle\Tests\DataGrid\Extension\Configuration\EventSubscriber;
 
+use FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\Loader\YamlFileLoader;
+use FSi\Bundle\DataGridBundle\DataGrid\Extension\Configuration\Locator\FileLocator;
 use FSi\Component\DataGrid\DataGridEvent;
 use FSi\Component\DataGrid\DataGridEvents;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -29,11 +31,16 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->kernel = $this->getMock('Symfony\Component\HttpKernel\Kernel', array(), array('dev', true));
-        $this->subscriber = new ConfigurationBuilder($this->kernel);
     }
 
     public function testSubscribedEvents()
     {
+        $this->kernel->expects($this->once())
+            ->method('getBundles')
+            ->will($this->returnValue(array()));
+
+        $this->initSubscriber();
+
         $this->assertEquals(
             $this->subscriber->getSubscribedEvents(),
             array(DataGridEvents::PRE_SET_DATA => array('readConfiguration', 128))
@@ -53,6 +60,8 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
 
                 return array($bundle);
             }));
+
+        $this->initSubscriber();
 
         $dataGrid = $this->getMockBuilder('FSi\Component\DataGrid\DataGrid')
             ->disableOriginalConstructor()
@@ -92,6 +101,8 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
                 );
             }));
 
+        $this->initSubscriber();
+
         $dataGrid = $this->getMockBuilder('FSi\Component\DataGrid\DataGrid')
             ->disableOriginalConstructor()
             ->getMock();
@@ -100,21 +111,238 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
             ->method('getName')
             ->will($this->returnValue('news'));
 
-        // 0 - 3 getName() is called
-        $dataGrid->expects($this->at(4))
+        $dataGrid->expects($this->at(1))
             ->method('addColumn')
             ->with('id', 'number', array('label' => 'ID'));
 
-        $dataGrid->expects($this->at(5))
+        $dataGrid->expects($this->at(2))
             ->method('addColumn')
             ->with('title', 'text', array());
 
-        $dataGrid->expects($this->at(6))
+        $dataGrid->expects($this->at(3))
             ->method('addColumn')
             ->with('author', 'text', array());
 
         $event = new DataGridEvent($dataGrid, array());
 
         $this->subscriber->readConfiguration($event);
+    }
+
+    public function testImportConfigurationFromSameBundle()
+    {
+        $self = $this;
+        $this->kernel->expects($this->once())
+            ->method('getBundles')
+            ->will($this->returnCallback(function() use ($self) {
+                $barBundle = $self->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
+                $barBundle->expects($self->any())
+                    ->method('getPath')
+                    ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/BarBundle'));
+
+                return array(
+                    $barBundle
+                );
+            }));
+
+        $this->initSubscriber();
+
+        $dataGrid = $this->getMockBuilder('FSi\Component\DataGrid\DataGrid')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $dataGrid->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('extended_news'));
+
+        $dataGrid->expects($this->at(1))
+            ->method('addColumn')
+            ->with('id', 'number', array('label' => 'ID'));
+
+        $dataGrid->expects($this->at(2))
+            ->method('addColumn')
+            ->with('title', 'text', array());
+
+        $dataGrid->expects($this->at(3))
+            ->method('addColumn')
+            ->with('author', 'text', array());
+
+        $dataGrid->expects($this->at(4))
+            ->method('addColumn')
+            ->with('actions', 'actions', array(
+                'field_mapping' => array('id'),
+                'actions' => array(
+                    'edit' => array(
+                        'route_name' => 'route_edit',
+                        'parameters_field_mapping' =>
+                            array('id' => 'id')
+                    )
+                )
+            ));
+
+        $event = new DataGridEvent($dataGrid, array());
+
+        $this->subscriber->readConfiguration($event);
+    }
+
+    public function testImportConfigurationFromAnotherBundle()
+    {
+        $self = $this;
+        $this->kernel->expects($this->once())
+            ->method('getBundles')
+            ->will($this->returnCallback(function() use ($self) {
+                $barBundle = $self->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
+                $barBundle->expects($self->any())
+                    ->method('getPath')
+                    ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/BarBundle'));
+
+                $bazBundle = $self->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
+                $bazBundle->expects($self->any())
+                    ->method('getPath')
+                    ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/BazBundle'));
+
+                return array(
+                    $barBundle,
+                    $bazBundle
+                );
+            }));
+
+        $this->kernel->expects($self->once())
+            ->method('locateResource')
+            ->with('@BarBundle/Resources/config/datagrid/news.yml', '', false)
+            ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/BarBundle/Resources/config/datagrid/news.yml'));
+
+        $this->initSubscriber();
+
+        $dataGrid = $this->getMockBuilder('FSi\Component\DataGrid\DataGrid')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $dataGrid->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('extended_news'));
+
+        $dataGrid->expects($this->at(1))
+            ->method('addColumn')
+            ->with('id', 'number', array('label' => 'ID'));
+
+        $dataGrid->expects($this->at(2))
+            ->method('addColumn')
+            ->with('title', 'text', array());
+
+        $dataGrid->expects($this->at(3))
+            ->method('addColumn')
+            ->with('author', 'text', array());
+
+        $dataGrid->expects($this->at(4))
+            ->method('addColumn')
+            ->with('actions', 'actions', array(
+                'field_mapping' => array('id'),
+                'actions' => array(
+                    'view' => array(
+                        'route_name' => 'route_view',
+                        'parameters_field_mapping' =>
+                            array('id' => 'id')
+                    )
+                )
+            ));
+
+        $event = new DataGridEvent($dataGrid, array());
+
+        $this->subscriber->readConfiguration($event);
+    }
+
+    public function testImportConfigurationFromDifferentSources()
+    {
+        $self = $this;
+        $this->kernel->expects($this->once())
+            ->method('getBundles')
+            ->will($this->returnCallback(function() use ($self) {
+                $fooBundle = $self->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
+                $fooBundle->expects($self->any())
+                    ->method('getPath')
+                    ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/FooBundle'));
+
+                $barBundle = $self->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
+                $barBundle->expects($self->any())
+                    ->method('getPath')
+                    ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/BarBundle'));
+
+                $bazBundle = $self->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
+                $bazBundle->expects($self->any())
+                    ->method('getPath')
+                    ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/BazBundle'));
+
+                return array(
+                    $barBundle,
+                    $bazBundle,
+                    $fooBundle,
+                );
+            }));
+
+        $this->kernel->expects($self->once())
+            ->method('locateResource')
+            ->with('@BarBundle/Resources/config/datagrid/extended_news.yml', '', false)
+            ->will($self->returnValue(__DIR__ . '/../../../../Fixtures/BarBundle/Resources/config/datagrid/extended_news.yml'));
+
+        $this->initSubscriber();
+
+        $dataGrid = $this->getMockBuilder('FSi\Component\DataGrid\DataGrid')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $dataGrid->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('extended_news'));
+
+        $dataGrid->expects($this->at(1))
+            ->method('addColumn')
+            ->with('id', 'number', array('label' => 'ID'));
+
+        $dataGrid->expects($this->at(2))
+            ->method('addColumn')
+            ->with('title', 'text', array());
+
+        $dataGrid->expects($this->at(3))
+            ->method('addColumn')
+            ->with('author', 'text', array());
+
+        $dataGrid->expects($this->at(4))
+            ->method('addColumn')
+            ->with('actions', 'actions', array(
+                'field_mapping' => array('id'),
+                'actions' => array(
+                    'edit' => array(
+                        'route_name' => 'route_edit',
+                        'parameters_field_mapping' =>
+                            array('id' => 'id')
+                    )
+                )
+            ));
+
+        $dataGrid->expects($this->at(5))
+            ->method('addColumn')
+            ->with('actions2', 'actions', array(
+                'field_mapping' => array('id'),
+                'actions' => array(
+                    'some_action' => array(
+                        'route_name' => 'route_some_action',
+                        'parameters_field_mapping' =>
+                            array('id' => 'id')
+                    )
+                )
+            ));
+
+        $event = new DataGridEvent($dataGrid, array());
+
+        $this->subscriber->readConfiguration($event);
+    }
+
+    protected function initSubscriber()
+    {
+        $this->subscriber = new ConfigurationBuilder(
+            new YamlFileLoader(
+                new FileLocator($this->kernel, '', 'Resources/config/datagrid')
+            )
+        );
     }
 }

--- a/Tests/DataGrid/Extension/Configuration/EventSubscriber/ConfigurationBuilderTest.php
+++ b/Tests/DataGrid/Extension/Configuration/EventSubscriber/ConfigurationBuilderTest.php
@@ -302,16 +302,7 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
         $this->subscriber->readConfiguration($event);
     }
 
-    protected function initSubscriber()
-    {
-        $this->subscriber = new ConfigurationBuilder(
-            new YamlFileLoader(
-                new FileLocator($this->kernel, '', self::$datagridConfigRelativePath)
-            )
-        );
-    }
-
-    protected function getBundleMock($bundleName)
+    public function getBundleMock($bundleName)
     {
         $bundleMock = $this->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
         $bundleMock->expects($this->any())
@@ -319,5 +310,14 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(self::$fixtureAppPath . '/' . $bundleName));
 
         return $bundleMock;
+    }
+
+    protected function initSubscriber()
+    {
+        $this->subscriber = new ConfigurationBuilder(
+            new YamlFileLoader(
+                new FileLocator($this->kernel, '', self::$datagridConfigRelativePath)
+            )
+        );
     }
 }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -28,13 +28,74 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testDeprecatedTemplateOption()
+    {
+        $this->setExpectedException('PHPUnit_Framework_Error_Deprecated');
+
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new Configuration(), array('fsi_data_grid' => array(
+            'twig' => array(
+                'template' => 'custom_datagrid.html.twig'
+            )
+        )));
+
+        $this->assertSame(
+            $config,
+            self::getBundleDefaultOptions()
+        );
+    }
+
+    public function testTemplateOption()
+    {
+        \PHPUnit_Framework_Error_Deprecated::$enabled = false;
+
+        $processor = new Processor();
+        $config = @$processor->processConfiguration(new Configuration(), array('fsi_data_grid' => array(
+            'twig' => array(
+                'template' => 'custom_datagrid.html.twig'
+            )
+        )));
+
+        $this->assertSame(
+            $config,
+            array(
+                'twig' => array(
+                    'enabled' => true,
+                    'themes' => array('custom_datagrid.html.twig')
+                ),
+                'yaml_configuration' => true
+            )
+        );
+    }
+
+    public function testThemesOption()
+    {
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new Configuration(), array('fsi_data_grid' => array(
+            'twig' => array(
+                'themes' => array('custom_datagrid.html.twig')
+            )
+        )));
+
+        $this->assertSame(
+            $config,
+            array(
+                'twig' => array(
+                    'themes' => array('custom_datagrid.html.twig'),
+                    'enabled' => true
+                ),
+                'yaml_configuration' => true
+            )
+        );
+    }
+
     public static function getBundleDefaultOptions()
     {
         return array(
             'yaml_configuration' => true,
             'twig' => array(
                 'enabled' => true,
-                'template' => 'datagrid.html.twig'
+                'themes' => array('datagrid.html.twig')
             )
         );
     }

--- a/Tests/Fixtures/BarBundle/Resources/config/datagrid/extended_news.yml
+++ b/Tests/Fixtures/BarBundle/Resources/config/datagrid/extended_news.yml
@@ -1,0 +1,11 @@
+imports:
+  - { resource: news.yml }
+columns:
+  actions:
+    type: actions
+    options:
+      field_mapping: ['id']
+      actions:
+        edit:
+          route_name: route_edit
+          parameters_field_mapping: {'id' : 'id'}

--- a/Tests/Fixtures/BazBundle/Resources/config/datagrid/extended_news.yml
+++ b/Tests/Fixtures/BazBundle/Resources/config/datagrid/extended_news.yml
@@ -1,0 +1,11 @@
+imports:
+  - { resource: BarBundle:news.yml }
+columns:
+  actions:
+    type: actions
+    options:
+      field_mapping: ['id']
+      actions:
+        view:
+          route_name: route_view
+          parameters_field_mapping: {'id' : 'id'}

--- a/Tests/Fixtures/FooBundle/Resources/config/datagrid/extended_news.yml
+++ b/Tests/Fixtures/FooBundle/Resources/config/datagrid/extended_news.yml
@@ -1,0 +1,11 @@
+imports:
+  - { resource: BarBundle:extended_news.yml }
+columns:
+  actions2:
+    type: actions
+    options:
+      field_mapping: ['id']
+      actions:
+        some_action:
+          route_name: route_some_action
+          parameters_field_mapping: {'id' : 'id'}

--- a/Tests/Twig/Extension/DataGridExtensionTest.php
+++ b/Tests/Twig/Extension/DataGridExtensionTest.php
@@ -53,7 +53,7 @@ class DataGridExtensionTest extends \PHPUnit_Framework_TestCase
         $twig->addGlobal('global_var', 'global_value');
         $this->twig = $twig;
 
-        $this->extension = new DataGridExtension('datagrid.html.twig');
+        $this->extension = new DataGridExtension(array('datagrid.html.twig'));
     }
 
     /**
@@ -62,7 +62,7 @@ class DataGridExtensionTest extends \PHPUnit_Framework_TestCase
      */
     public function testInitRuntimeShouldThrowExceptionBecauseNotExistingTheme()
     {
-        $this->twig->addExtension(new DataGridExtension('this_is_not_valid_path.html.twig'));
+        $this->twig->addExtension(new DataGridExtension(array('this_is_not_valid_path.html.twig')));
         $this->twig->initRuntime();
     }
 
@@ -200,6 +200,63 @@ class DataGridExtensionTest extends \PHPUnit_Framework_TestCase
         $datagridView = $this->getDataGridView('grid');
 
         $template->expects($this->at(3))
+            ->method('displayBlock')
+            ->with('datagrid', array(
+                'datagrid' => $datagridView,
+                'vars' => array(),
+                'global_var' => 'global_value'
+            ))
+            ->will($this->returnValue(true));
+
+        $this->extension->datagrid($datagridView);
+    }
+
+    public function testDataGridMultipleTemplates()
+    {
+        $this->twig->addExtension($this->extension);
+        $this->twig->initRuntime();
+
+        $template1 = $this->getMock('\Twig_TemplateInterface', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent'));
+        $template1->expects($this->at(0))
+            ->method('hasBlock')
+            ->with('datagrid_grid')
+            ->will($this->returnValue(false));
+
+        $template1->expects($this->at(1))
+            ->method('getParent')
+            ->with(array())
+            ->will($this->returnValue(false));
+
+        $template1->expects($this->at(2))
+            ->method('hasBlock')
+            ->with('datagrid')
+            ->will($this->returnValue(true));
+
+        $template2 = $this->getMock('\Twig_TemplateInterface', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent'));
+        $template2->expects($this->at(0))
+            ->method('hasBlock')
+            ->with('datagrid_grid')
+            ->will($this->returnValue(false));
+
+        $template2->expects($this->at(1))
+            ->method('getParent')
+            ->with(array())
+            ->will($this->returnValue(false));
+
+        $template2->expects($this->at(2))
+            ->method('hasBlock')
+            ->with('datagrid')
+            ->will($this->returnValue(false));
+
+        $template2->expects($this->at(3))
+            ->method('getParent')
+            ->with(array())
+            ->will($this->returnValue(false));
+
+        $this->extension->setBaseTheme(array($template1, $template2));
+        $datagridView = $this->getDataGridView('grid');
+
+        $template1->expects($this->at(3))
             ->method('displayBlock')
             ->with('datagrid', array(
                 'datagrid' => $datagridView,

--- a/Twig/Extension/DataGridExtension.php
+++ b/Twig/Extension/DataGridExtension.php
@@ -34,7 +34,7 @@ class DataGridExtension extends \Twig_Extension
     /**
      * @var \Twig_TemplateInterface
      */
-    private $baseTemplate;
+    private $baseThemes;
 
     /**
      * @var \Twig_Environment
@@ -42,13 +42,13 @@ class DataGridExtension extends \Twig_Extension
     private $environment;
 
     /**
-     * @param string $template
+     * @param string $themes
      */
-    public function __construct($template)
+    public function __construct(array $themes)
     {
         $this->themes = array();
         $this->themesVars = array();
-        $this->baseTemplate = $template;
+        $this->baseThemes = $themes;
     }
 
     /**
@@ -65,7 +65,9 @@ class DataGridExtension extends \Twig_Extension
     public function initRuntime(\Twig_Environment $environment)
     {
         $this->environment = $environment;
-        $this->themes[self::DEFAULT_THEME] = $this->environment->loadTemplate($this->baseTemplate);
+        for ($i = count($this->baseThemes) - 1; $i >= 0; $i--) {
+            $this->baseThemes[$i] = $this->environment->loadTemplate($this->baseThemes[$i]);
+        }
     }
 
     /**
@@ -114,15 +116,20 @@ class DataGridExtension extends \Twig_Extension
     }
 
     /**
-     * Set base theme.
+     * Set base theme or themes.
      *
      * @param $theme
      */
     public function setBaseTheme($theme)
     {
-        $this->themes[self::DEFAULT_THEME] = ($theme instanceof \Twig_TemplateInterface)
-            ? $theme
-            : $this->environment->loadTemplate($theme);
+        $themes = is_array($theme) ? $theme : array($theme);
+
+        $this->baseThemes = array();
+        foreach ($themes as $theme) {
+            $this->baseThemes[] = ($theme instanceof \Twig_TemplateInterface)
+                ? $theme
+                : $this->environment->loadTemplate($theme);
+        }
     }
 
     /**
@@ -359,7 +366,9 @@ class DataGridExtension extends \Twig_Extension
             $templates[] = $this->themes[$dataGrid->getName()];
         }
 
-        $templates[] = $this->themes[self::DEFAULT_THEME];
+        for ($i = count($this->baseThemes) - 1; $i >= 0; $i--) {
+            $templates[] = $this->baseThemes[$i];
+        }
 
         return $templates;
     }
@@ -419,6 +428,7 @@ class DataGridExtension extends \Twig_Extension
 
         // Check parents
         if (false !== ($parent = $template->getParent(array()))) {
+            var_dump($parent);
             return $this->findTemplateWithBlock($parent, $blockName);
         }
 


### PR DESCRIPTION
This PR solves #43 with some differences. This implementation uses https://github.com/symfony/config and https://github.com/symfony/HttpKernel to locate configuration files. It allows only two formats of imports:

``` yml
imports:
  - { resource: datagrid_extension.yml } # it will search for datagrid_extension.yml in the same folder as the current configuration file. 
  - { resource: FSiDemoBundle:datagrid_extenion.yml } # it will search for configuration in src/FSi/DemoBundle/Resources/config/datagrid/datagrid_extension.yml
```

However thanks to the `\Symfony\Component\HttpKernel\Kernel.php::locateResource()` method it is also possible to overwrite datagrid configurations from different bundles in `app/Resources` folder as easy as any other resources in Symfony 2 application.

Another benefit of this implementation is that it is possible to load datagrid configuration directly from specific bundle when creating datagrid:

```
$dataGrid = $dataGridFactory->createDataGrid('FSiDemoBundle:datagrid') # it will search for configuration in src/FSi/DemoBundle/Resources/config/datagrid/datagrid.yml
```
