### PR TITLE
Fixed rendering blocks from parent templates

### DIFF
--- a/Tests/Twig/Extension/DataGridExtensionTest.php
+++ b/Tests/Twig/Extension/DataGridExtensionTest.php
@@ -179,7 +179,7 @@ class DataGridExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $this->twig->addExtension($this->extension);
         $this->twig->initRuntime();
-        $template = $this->getMock('\Twig_TemplateInterface', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent'));
+        $template = $this->getMock('\Twig_Template', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent', 'getTemplateName', 'doDisplay'), array($this->twig));
 
         $template->expects($this->at(0))
             ->method('hasBlock')
@@ -216,7 +216,7 @@ class DataGridExtensionTest extends \PHPUnit_Framework_TestCase
         $this->twig->addExtension($this->extension);
         $this->twig->initRuntime();
 
-        $template1 = $this->getMock('\Twig_TemplateInterface', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent'));
+        $template1 = $this->getMock('\Twig_Template', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent', 'getTemplateName', 'doDisplay'), array($this->twig));
         $template1->expects($this->at(0))
             ->method('hasBlock')
             ->with('datagrid_grid')
@@ -232,7 +232,7 @@ class DataGridExtensionTest extends \PHPUnit_Framework_TestCase
             ->with('datagrid')
             ->will($this->returnValue(true));
 
-        $template2 = $this->getMock('\Twig_TemplateInterface', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent'));
+        $template2 = $this->getMock('\Twig_Template', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent', 'getTemplateName', 'doDisplay'), array($this->twig));
         $template2->expects($this->at(0))
             ->method('hasBlock')
             ->with('datagrid_grid')
@@ -273,8 +273,8 @@ class DataGridExtensionTest extends \PHPUnit_Framework_TestCase
         $this->twig->addExtension($this->extension);
         $this->twig->initRuntime();
 
-        $parent = $this->getMock('\Twig_TemplateInterface', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent'));
-        $template = $this->getMock('\Twig_TemplateInterface', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent'));
+        $template = $this->getMock('\Twig_Template', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent', 'getTemplateName', 'doDisplay'), array($this->twig));
+        $parent = $this->getMock('\Twig_Template', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent', 'getTemplateName', 'doDisplay'), array($this->twig));
 
         $template->expects($this->at(0))
             ->method('hasBlock')
@@ -304,7 +304,7 @@ class DataGridExtensionTest extends \PHPUnit_Framework_TestCase
         $this->extension->setBaseTheme($template);
         $datagridView = $this->getDataGridView('grid');
 
-        $parent->expects($this->at(1))
+        $template->expects($this->at(4))
             ->method('displayBlock')
             ->with('datagrid', array(
                 'datagrid' => $datagridView,
@@ -320,7 +320,7 @@ class DataGridExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $this->twig->addExtension($this->extension);
         $this->twig->initRuntime();
-        $template = $this->getMock('\Twig_TemplateInterface', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent'));
+        $template = $this->getMock('\Twig_Template', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent', 'getTemplateName', 'doDisplay'), array($this->twig));
 
         $template->expects($this->at(0))
             ->method('hasBlock')
@@ -360,7 +360,7 @@ class DataGridExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $this->twig->addExtension($this->extension);
         $this->twig->initRuntime();
-        $template = $this->getMock('\Twig_TemplateInterface', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent'));
+        $template = $this->getMock('\Twig_Template', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent', 'getTemplateName', 'doDisplay'), array($this->twig));
 
         $template->expects($this->at(0))
             ->method('hasBlock')
@@ -443,7 +443,7 @@ class DataGridExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $this->twig->addExtension($this->extension);
         $this->twig->initRuntime();
-        $template = $this->getMock('\Twig_TemplateInterface', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent'));
+        $template = $this->getMock('\Twig_Template', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent', 'getTemplateName', 'doDisplay'), array($this->twig));
 
         $template->expects($this->at(0))
             ->method('hasBlock')
@@ -479,7 +479,7 @@ class DataGridExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $this->twig->addExtension($this->extension);
         $this->twig->initRuntime();
-        $template = $this->getMock('\Twig_TemplateInterface', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent'));
+        $template = $this->getMock('\Twig_Template', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent', 'getTemplateName', 'doDisplay'), array($this->twig));
 
         $template->expects($this->at(0))
             ->method('hasBlock')
@@ -571,7 +571,7 @@ class DataGridExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $this->twig->addExtension($this->extension);
         $this->twig->initRuntime();
-        $template = $this->getMock('\Twig_TemplateInterface', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent'));
+        $template = $this->getMock('\Twig_Template', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent', 'getTemplateName', 'doDisplay'), array($this->twig));
 
         $template->expects($this->at(0))
             ->method('hasBlock')
@@ -659,7 +659,7 @@ class DataGridExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $this->twig->addExtension($this->extension);
         $this->twig->initRuntime();
-        $template = $this->getMock('\Twig_TemplateInterface', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent'));
+        $template = $this->getMock('\Twig_Template', array('hasBlock', 'render', 'display', 'getEnvironment', 'displayBlock', 'getParent', 'getTemplateName', 'doDisplay'), array($this->twig));
 
         $template->expects($this->at(0))
             ->method('hasBlock')

--- a/Twig/Extension/DataGridExtension.php
+++ b/Twig/Extension/DataGridExtension.php
@@ -32,7 +32,7 @@ class DataGridExtension extends \Twig_Extension
     private $themesVars;
 
     /**
-     * @var \Twig_TemplateInterface
+     * @var \Twig_Template[]
      */
     private $baseThemes;
 
@@ -108,7 +108,7 @@ class DataGridExtension extends \Twig_Extension
      */
     public function setTheme(DataGridViewInterface $dataGrid, $theme, array $vars = array())
     {
-        $this->themes[$dataGrid->getName()] = ($theme instanceof \Twig_TemplateInterface)
+        $this->themes[$dataGrid->getName()] = ($theme instanceof \Twig_Template)
             ? $theme
             : $this->environment->loadTemplate($theme);
 
@@ -126,7 +126,7 @@ class DataGridExtension extends \Twig_Extension
 
         $this->baseThemes = array();
         foreach ($themes as $theme) {
-            $this->baseThemes[] = ($theme instanceof \Twig_TemplateInterface)
+            $this->baseThemes[] = ($theme instanceof \Twig_Template)
                 ? $theme
                 : $this->environment->loadTemplate($theme);
         }
@@ -416,11 +416,11 @@ class DataGridExtension extends \Twig_Extension
     }
 
     /**
-     * @param \Twig_TemplateInterface $template
+     * @param \Twig_Template $template
      * @param string $blockName
-     * @return \Twig_TemplateInterface|bool
+     * @return \Twig_Template|bool
      */
-    private function findTemplateWithBlock(\Twig_TemplateInterface $template, $blockName)
+    private function findTemplateWithBlock(\Twig_Template $template, $blockName)
     {
         if ($template->hasBlock($blockName)) {
             return $template;
@@ -428,7 +428,8 @@ class DataGridExtension extends \Twig_Extension
 
         // Check parents
         if (false !== ($parent = $template->getParent(array()))) {
-            return $this->findTemplateWithBlock($parent, $blockName);
+            if ($this->findTemplateWithBlock($parent, $blockName) !== false)
+                return $template;
         }
 
         return false;


### PR DESCRIPTION
- Fixed rendering blocks from parent templates
- Removed usage of deprecated \Twig_TemplateInterface