### PR TITLE
datagrid.html.twig action.url issue

### DIFF
--- a/DataGrid/Extension/Symfony/ColumnType/Action.php
+++ b/DataGrid/Extension/Symfony/ColumnType/Action.php
@@ -11,7 +11,6 @@ namespace FSi\Bundle\DataGridBundle\DataGrid\Extension\Symfony\ColumnType;
 
 use FSi\Component\DataGrid\Column\ColumnAbstractType;
 use FSi\Component\DataGrid\Exception\UnexpectedTypeException;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\RouterInterface;

--- a/Resources/views/datagrid.html.twig
+++ b/Resources/views/datagrid.html.twig
@@ -41,7 +41,7 @@
                     cell,
                     action_name,
                     action.content,
-                    action.url_attr|merge({'href' : action.url}),
+                    action.url_attr,
                     action.field_mapping_values
                 ) }}
             {% endfor %}


### PR DESCRIPTION
In `datagrid.html.twig `, `action.url` does not exist (I checked the code in `Action.php`) and so cannot be merged into `action.url_attr`. This causes an critical error for Symfony.

Also, when looking in Action.php I noticed that
`Symfony\Component\DependencyInjection\ContainerInterface` is never used,
so I removed it.