### PR TITLE
Allow custom datamapper (through compiler pass)

### DIFF
--- a/DataGridBundle.php
+++ b/DataGridBundle.php
@@ -12,6 +12,7 @@ namespace FSi\Bundle\DataGridBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use FSi\Bundle\DataGridBundle\DependencyInjection\Compiler\DataGridPass;
+use FSi\Bundle\DataGridBundle\DependencyInjection\Compiler\DataMapperPass;
 use FSi\Bundle\DataGridBundle\DependencyInjection\Compiler\TemplatePathPass;
 use FSi\Bundle\DataGridBundle\DependencyInjection\FSIDataGridExtension;
 
@@ -26,6 +27,7 @@ class DataGridBundle extends Bundle
     {
         parent::build($container);
         $container->addCompilerPass(new DataGridPass());
+        $container->addCompilerPass(new DataMapperPass());
         $container->addCompilerPass(new TemplatePathPass());
     }
 

--- a/DependencyInjection/Compiler/DataMapperPass.php
+++ b/DependencyInjection/Compiler/DataMapperPass.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * (c) Fabryka Stron Internetowych sp. z o.o <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\DataGridBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Compiler pass to assemble datagrid mappers into the mappers chain.
+ */
+class DataMapperPass implements CompilerPassInterface
+{
+    /**
+     * Collects services that have a mapper tag ("datagrid.data_mapper"),
+     * sorts by their priorities and inject them to chain mapper. Priority
+     * attribute should be represented as a number.
+     *
+     * @param ContainerBuilder $container Container builder
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('datagrid.data_mapper.chain')) {
+            return;
+        }
+
+        $dataMappers = array();
+
+        foreach ($container->findTaggedServiceIds('datagrid.data_mapper') as $serviceId => $tag) {
+            $priority = isset($tag[0]['priority'])
+                ? $tag[0]['priority']
+                : 0;
+
+            $dataMappers[$priority] = new Reference($serviceId);
+        }
+
+        ksort($dataMappers, SORT_NUMERIC);
+
+        $container->getDefinition('datagrid.data_mapper.chain')->replaceArgument(0, $dataMappers);
+    }
+}

--- a/Resources/config/datagrid.xml
+++ b/Resources/config/datagrid.xml
@@ -25,16 +25,17 @@
         </service>
 
         <!-- DataMapper\Reflection -->
-        <service id="datagrid.data_mapper.reflection" class="%datagrid.data_mapper.reflection.class%" />
+        <service id="datagrid.data_mapper.reflection" class="%datagrid.data_mapper.reflection.class%">
+          <tag name="datagrid.data_mapper" priority="20"/>
+        </service>
         <!-- DataMapper\PropertyAccessorMapper -->
-        <service id="datagrid.data_mapper.property_accessor" class="%datagrid.data_mapper.property_accessor.class%" />
+        <service id="datagrid.data_mapper.property_accessor" class="%datagrid.data_mapper.property_accessor.class%">
+          <tag name="datagrid.data_mapper" priority="10"/>
+        </service>
 
         <!-- DataMapper\Chain -->
         <service id="datagrid.data_mapper.chain" class="%datagrid.data_mapper.chain.class%">
-            <argument type="collection">
-                <argument type="service" id="datagrid.data_mapper.property_accessor" />
-                <argument type="service" id="datagrid.data_mapper.reflection" />
-            </argument>
+            <argument type="collection"/>
         </service>
 
         <!-- DataGridFactory -->

--- a/Tests/DependencyInjection/Compiler/DataMapperPassTest.php
+++ b/Tests/DependencyInjection/Compiler/DataMapperPassTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * (c) Fabryka Stron Internetowych sp. z o.o <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\DataGridBundle\Tests\DependencyInjection\Compiler;
+
+use FSi\Bundle\DataGridBundle\DependencyInjection\Compiler\DataMapperPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * @see FSi\Bundle\DataGridBundle\DependencyInjection\Compiler\DataMapperPass
+ */
+class DataMapperPassTest extends TestCase
+{
+    /**
+     * Container stub.
+     *
+     * @var ContainerBuilder
+     */
+    private $container;
+
+    /**
+     * Definition of chain datamapper.
+     *
+     * @var Definition
+     */
+    private $chainDefinition;
+
+    /**
+     * Initialize container stub with fixture services.
+     */
+    protected function setUp()
+    {
+        $this->container = new ContainerBuilder();
+
+        $chainMapperClass      = 'FSi\Component\DataGrid\DataMapper\ChainMapper';
+        $this->chainDefinition = new Definition($chainMapperClass, array(array()));
+
+        $this->container->setDefinition('datagrid.data_mapper.chain', $this->chainDefinition);
+
+        $mappersPriorities = array(
+            'third_mapper'  => 30,
+            'first_mapper'  => 10,
+            'second_mapper' => 20,
+        );
+
+        foreach ($mappersPriorities as $serviceId => $priority) {
+            $mapperDefinition = new Definition('Whatever');
+            $mapperDefinition->addTag('datagrid.data_mapper', ['priority' => $priority]);
+            $this->container->setDefinition($serviceId, $mapperDefinition);
+        }
+    }
+
+    /**
+     * Test that tagged services are passed into chain mapper.
+     */
+    public function testProcessRegular()
+    {
+        $pass = new DataMapperPass();
+        $pass->process($this->container);
+
+        $chainDefinition = $this->container->getDefinition('datagrid.data_mapper.chain');
+        $this->assertSame($this->chainDefinition, $chainDefinition);
+
+        $arguments = $chainDefinition->getArguments();
+        $this->assertCount(1, $arguments);
+
+        $expectedReferences = array(
+            10 => new Reference('first_mapper'),
+            20 => new Reference('second_mapper'),
+            30 => new Reference('third_mapper'),
+        );
+
+        $this->assertEquals($expectedReferences, $arguments[0]);
+    }
+
+    /**
+     * Test that tagged services are not passed into chain mapper when container
+     * has not chain mapper definition.
+     */
+    public function testNoChainDefinition()
+    {
+        $this->container->removeDefinition('datagrid.data_mapper.chain');
+
+        $pass = new DataMapperPass();
+        $pass->process($this->container);
+
+        $this->assertFalse($this->container->hasDefinition('datagrid.data_mapper.chain'));
+        $this->assertEquals(array(array()), $this->chainDefinition->getArguments());
+    }
+}


### PR DESCRIPTION
For issues #67 and fsi-open/datagrid#63.

PR implements a compiler pass to register datamappers in the chain by service tagging. Tag `datagrid.data_mapper` allows to set the `priority` attribute, so it is possible to make any sequence of mappers.

edit: fixes #67
