### PR TITLE
pass cell view and action name to action template

### DIFF
--- a/Tests/Twig/Extension/DataGridExtensionTest.php
+++ b/Tests/Twig/Extension/DataGridExtensionTest.php
@@ -716,7 +716,7 @@ class DataGridExtensionTest extends \PHPUnit_Framework_TestCase
         $template->expects($this->at(7))
             ->method('displayBlock')
             ->with('datagrid_column_type_action_cell_action', array(
-                'cell_view' => $cellView,
+                'cell' => $cellView,
                 'action' => 'edit',
                 'content' => 'content',
                 'attr' => array(),

--- a/Tests/Twig/Extension/DataGridExtensionTest.php
+++ b/Tests/Twig/Extension/DataGridExtensionTest.php
@@ -716,6 +716,8 @@ class DataGridExtensionTest extends \PHPUnit_Framework_TestCase
         $template->expects($this->at(7))
             ->method('displayBlock')
             ->with('datagrid_column_type_action_cell_action', array(
+                'cell_view' => $cellView,
+                'action' => 'edit',
                 'content' => 'content',
                 'attr' => array(),
                 'translation_domain' => null,

--- a/Twig/Extension/DataGridExtension.php
+++ b/Twig/Extension/DataGridExtension.php
@@ -318,6 +318,8 @@ class DataGridExtension extends \Twig_Extension
         );
 
         $context = array(
+            'cell_view' => $view,
+            'action' => $action,
             'content' => $content,
             'attr' => $urlAttrs,
             'translation_domain' => $view->getAttribute('translation_domain'),

--- a/Twig/Extension/DataGridExtension.php
+++ b/Twig/Extension/DataGridExtension.php
@@ -318,7 +318,7 @@ class DataGridExtension extends \Twig_Extension
         );
 
         $context = array(
-            'cell_view' => $view,
+            'cell' => $view,
             'action' => $action,
             'content' => $content,
             'attr' => $urlAttrs,


### PR DESCRIPTION
if you want for example access to whole row object (called source in CellView instance) in action template.